### PR TITLE
Automatically resolve constant references

### DIFF
--- a/docs/tutorial/Tutorial - Part I.md
+++ b/docs/tutorial/Tutorial - Part I.md
@@ -87,7 +87,7 @@ The library also supports abstractions for properties requiring color values. Yo
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants |
+  with: [:style |
     style
       backgroundColor: #aliceBlue;
       borderColor: (CssRGBColor red: 0 green: 128 blue: 0 alpha: 0.5)];
@@ -128,7 +128,7 @@ A lot of values for CSS properties are just keyword constants. You can reference
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style textAlign: #justify ];
+  with: [:style | style textAlign: #justify ];
   build
 ```
 Evaluates to:
@@ -257,7 +257,7 @@ This kind of expressions allows descendant elements to cycle over a list of valu
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector unorderedList unorderedList ]
-  with: [:style :constants | style listStyleType: (CssToggle cyclingOver: { #disc. #circle. #square}) ];
+  with: [:style | style listStyleType: (CssToggle cyclingOver: { #disc. #circle. #square}) ];
   build
 ```
 Evaluates to:
@@ -290,7 +290,7 @@ or providing also the type or unit of the attribute (if no type or unit is speci
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div  ]
-  with: [:style :constants | style width: (CssAttributeReference toAttributeNamed: 'height' ofType: #pixel) ];
+  with: [:style | style width: (CssAttributeReference toAttributeNamed: 'height' ofType: #pixel) ];
   build
 ```
 Evaluates to:
@@ -320,7 +320,7 @@ div::before
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div before ]
-  with: [:style :constants | style content: (CssAttributeReference toAttributeNamed: 'height' ofType: #pixel withFallback: 10 px) ];
+  with: [:style | style content: (CssAttributeReference toAttributeNamed: 'height' ofType: #pixel withFallback: 10 px) ];
   build
 ```
 Evaluates to:

--- a/docs/tutorial/Tutorial - Part I.md
+++ b/docs/tutorial/Tutorial - Part I.md
@@ -82,14 +82,14 @@ CascadingStyleSheetBuilder new
 
 #### Colors
 
-The library also supports abstractions for properties requiring color values. The second block on the builder can be used to access constants provided by the library. So `constants >> #colors` provides easy access to colors in the SVG 1.0 list, and the abstractions `CssRGBColor` and `CssHSLColor` allow the creation of colors in the RGB or HSL space including alpha support.
+The library also supports abstractions for properties requiring color values. You can reference the colors in the SVG 1.0 list by name, and the abstractions `CssRGBColor` and `CssHSLColor` allow the creation of colors in the RGB or HSL space including alpha support. To get the list of supported colors inspect `RenoirSt constants >> #colors`.
 
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div ]
   with: [:style :constants |
     style
-      backgroundColor: constants >> #colors >> #aliceBlue;
+      backgroundColor: #aliceBlue;
       borderColor: (CssRGBColor red: 0 green: 128 blue: 0 alpha: 0.5)];
   build
 ```
@@ -123,12 +123,12 @@ Notice the difference in the message used because there is no alpha channel spec
 
 #### Constants
 
-A lot of values for CSS properties are just keyword constants. This support is in the second argument in the builder.
+A lot of values for CSS properties are just keyword constants. You can reference it by keyword, inspect `RenoirSt constants` to get the list of supported ones.
 
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style textAlign: constants >> #justify ];
+  with: [:style :constants | style textAlign: #justify ];
   build
 ```
 Evaluates to:
@@ -257,7 +257,7 @@ This kind of expressions allows descendant elements to cycle over a list of valu
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector unorderedList unorderedList ]
-  with: [:style :constants | style listStyleType: (CssToggle cyclingOver: { constants >> #disc. constants >> #circle. constants >> #square}) ];
+  with: [:style :constants | style listStyleType: (CssToggle cyclingOver: { #disc. #circle. #square}) ];
   build
 ```
 Evaluates to:
@@ -290,7 +290,7 @@ or providing also the type or unit of the attribute (if no type or unit is speci
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div  ]
-  with: [:style :constants | style width: (CssAttributeReference toAttributeNamed: 'height' ofType: constants >> #units >> #pixel) ];
+  with: [:style :constants | style width: (CssAttributeReference toAttributeNamed: 'height' ofType: #pixel) ];
   build
 ```
 Evaluates to:
@@ -320,7 +320,7 @@ div::before
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div before ]
-  with: [:style :constants | style content: (CssAttributeReference toAttributeNamed: 'height' ofType: constants >> #units >> #pixel withFallback: 10 px) ];
+  with: [:style :constants | style content: (CssAttributeReference toAttributeNamed: 'height' ofType: #pixel withFallback: 10 px) ];
   build
 ```
 Evaluates to:
@@ -331,6 +331,8 @@ div::before
 }
 ```
 
+To get a list of the supported units inspect `RenoirSt constants >> #units`.
+
 #### Gradients: `linear-gradient()` `radial-gradient()` `repeating-linear-gradient()` `repeating-radial-gradient()`
 
 A gradient is an image that smoothly fades from one color to another. These are commonly used for subtle shading in background images, buttons, and many other things. The gradient notations described in this section allow an author to specify such an image in a terse syntax, so that the UA can generate the image automatically when rendering the page. This notation is supported using `CssLinearGradient` and `CssRadialGradient` asbtractions.
@@ -340,17 +342,17 @@ Let's see some examples for linear gradients:
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style background: (CssLinearGradient fading: { constants >> #colors >> #yellow. constants >> #colors >> #blue }) ];
+  with: [:style | style background: (CssLinearGradient fading: { #yellow. #blue }) ];
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style background: (CssLinearGradient to: constants >> #bottom fading: { constants >> #colors >> #yellow. constants >> #colors >> #blue }) ];
+  with: [:style | style background: (CssLinearGradient to: #bottom fading: { #yellow. #blue }) ];
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style background: (CssLinearGradient rotated: 45 deg fading: { constants >> #colors >> #yellow. constants >> #colors >> #blue }) ];
+  with: [:style | style background: (CssLinearGradient rotated: 45 deg fading: { #yellow. #blue }) ];
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style background: (CssLinearGradient rotated: 90 deg fading: { constants >> #colors >> #yellow. (CssColorStop for: constants >> #colors >> #blue at: 30 percent) }) ];
+  with: [:style | style background: (CssLinearGradient rotated: 90 deg fading: { #yellow. (CssColorStop for: #blue at: 30 percent) }) ];
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style background: (CssLinearGradient fading: { constants >> #colors >> #yellow. (CssColorStop for: constants >> #colors >> #blue at: 20 percent). constants >> #colors >> #green}) ];
+  with: [:style | style background: (CssLinearGradient fading: { #yellow. (CssColorStop for: #blue at: 20 percent). #green}) ];
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style background: (CssLinearGradient to: { constants >> #top. constants >> #right } fading: { constants >> #colors >> #red.  constants >> #colors >> #white. constants >> #colors >> #blue }) ];
+  with: [:style | style background: (CssLinearGradient to: { #top. #right } fading: { #red.  #white. #blue }) ];
   build
 ```
 
@@ -392,13 +394,13 @@ and some for radial gradients:
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style background: (CssRadialGradient fading: { constants >> #colors >> #yellow. constants >> #colors >> #green }) ];
+  with: [:style | style background: (CssRadialGradient fading: { #yellow. #green }) ];
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style background: (CssRadialGradient elliptical: constants >> #farthestCorner at: constants >> #center fading: { constants >> #colors >> #yellow. constants >> #colors >> #green }) ];
+  with: [:style | style background: (CssRadialGradient elliptical: #farthestCorner at: #center fading: { #yellow. #green }) ];
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style background: (CssRadialGradient elliptical: constants >> #farthestSide at: { constants >> #left. constants >> #bottom} fading: { constants >> #colors >> #red. (CssColorStop for: constants >> #colors >> #yellow at: 50 px). constants >> #colors >> #green }) ];
+  with: [:style | style background: (CssRadialGradient elliptical: #farthestSide at: { #left. #bottom} fading: { #red. (CssColorStop for: #yellow at: 50 px). #green }) ];
   declareRuleSetFor: [:selector | selector div ]
-  with: [:style :constants | style background: (CssRadialGradient elliptical: {20 px. 30 px} at: { 20 px. 30 px} fading: { constants >> #colors >> #red. constants >> #colors >> #yellow. constants >> #colors >> #green }) ];
+  with: [:style | style background: (CssRadialGradient elliptical: {20 px. 30 px} at: { 20 px. 30 px} fading: { #red. #yellow. #green }) ];
   build
 ```
 evaluates to:
@@ -426,7 +428,7 @@ div
 
 To make the gradient repeatable, just send to it the message `beRepeating`. For Example:
 ```smalltalk
-(CssRadialGradient fading: { CssSVGColors yellow. CssSVGColors green }) beRepeating
+(CssRadialGradient fading: { #yellow. #green }) beRepeating
 ```
 renders as:
 ```css
@@ -438,20 +440,20 @@ repeating-radial-gradient(yellow, green);
 This abstraction simplifies the use of the `box-shadow` property. Let's see some examples:
 
 ```smalltalk
-CssBoxShadow horizontalOffset: 64 px verticalOffset: 64 px blurRadius: 12 px  spreadDistance: 40 px color: (CssConstants >> #colors >> #black newWithAlpha: 0.4)
+CssBoxShadow horizontalOffset: 64 px verticalOffset: 64 px blurRadius: 12 px  spreadDistance: 40 px color: #black
 ```
 renders as:
 ```css
-64px 64px 12px 40px rgba(0,0,0,0.4)
+64px 64px 12px 40px black
 ```
 
 ```smalltalk
-(CssBoxShadow horizontalOffset: 64 px verticalOffset: 64 px blurRadius: 12 px  spreadDistance: 40 px color: (CssConstants >> #colors >> #black newWithAlpha: 0.4)) ,
-(CssBoxShadow horizontalOffset: 12 px verticalOffset: 11 px blurRadius: 0 px  spreadDistance: 8 px color: (CssConstants >> #colors >> #black newWithAlpha: 0.4)) beInset
+(CssBoxShadow horizontalOffset: 64 px verticalOffset: 64 px blurRadius: 12 px  spreadDistance: 40 px color: #black) ,
+(CssBoxShadow horizontalOffset: 12 px verticalOffset: 11 px blurRadius: 0 px  spreadDistance: 8 px color: #black ) beInset
 ```
 renders as:
 ```css
-64px 64px 12px 40px rgba(0,0,0,0.4), inset 12px 11px 0px 8px rgba(0,0,0,0.4)
+64px 64px 12px 40px black, inset 12px 11px 0px 8px black
 ```
 
 [Go to next chapter](Tutorial - Part II.md)

--- a/docs/tutorial/Tutorial - Part II.md
+++ b/docs/tutorial/Tutorial - Part II.md
@@ -12,7 +12,7 @@ These selectors match a specific element type in the DOM. The library provides o
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector orderedList ]
-  with: [:style :constants | style listStyleType: constants >> #lowerRoman ];
+  with: [:style | style listStyleType: #lowerRoman ];
   build
 ```
 ```css
@@ -30,7 +30,7 @@ One of the most common use cases is the **descendant combinator**.
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div orderedList ]
-  with: [:style :constants | style listStyleType: constants >> #lowerRoman ];
+  with: [:style | style listStyleType: #lowerRoman ];
   build
 ```
 ```css
@@ -44,7 +44,7 @@ In case you need to use parenthesis in the right part of the expression, use `/`
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div / (selector class: 'custom') ]
-  with: [:style :constants | style listStyleType: constants >> #lowerRoman ];
+  with: [:style | style listStyleType: #lowerRoman ];
   build
 ```
 ```css
@@ -58,7 +58,7 @@ div .custom
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div > selector orderedList ]
-  with: [:style :constants | style listStyleType: constants >> #lowerRoman ];
+  with: [:style | style listStyleType: #lowerRoman ];
   build
 ```
 ```css
@@ -72,7 +72,7 @@ div > ol
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div + selector orderedList ]
-  with: [:style :constants | style listStyleType: constants >> #lowerRoman ];
+  with: [:style | style listStyleType: #lowerRoman ];
   build
 ```
 ```css
@@ -84,7 +84,7 @@ div + ol
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector div ~ selector orderedList ]
-  with: [:style :constants | style listStyleType: constants >> #lowerRoman ];
+  with: [:style | style listStyleType: #lowerRoman ];
   build
 ```
 ```css
@@ -98,7 +98,7 @@ div ~ ol
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | (selector div class: 'pastoral') id: #account5 ]
-  with: [:style :constants | style listStyleType: constants >> #lowerRoman ];
+  with: [:style | style listStyleType: #lowerRoman ];
   build
 ```
 ```css
@@ -119,7 +119,7 @@ Attribute presence:
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector h1 havingAttribute: 'title' ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
   build
 ```
 ```css
@@ -133,7 +133,7 @@ exact attribute value matching:
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector span withAttribute: 'class' equalTo: 'example' ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
   build
 ```
 ```css
@@ -148,7 +148,7 @@ inclusion:
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector anchor attribute: 'rel' includes: 'copyright' ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
   build
 ```
 ```css
@@ -162,7 +162,7 @@ and:
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector anchor firstValueOfAttribute: 'hreflang' beginsWith: 'en' ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
   build
 ```
 ```css
@@ -182,7 +182,7 @@ This selectors are provided for matching substrings in the value of an attribute
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector anchor attribute: 'type' beginsWith: 'image/' ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
   build
 ```
 ```css
@@ -195,7 +195,7 @@ a[type^="image/"]
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector anchor attribute: 'type' endsWith: '.html' ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
   build
 ```
 ```css
@@ -208,7 +208,7 @@ a[type$=".html"]
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector paragraph attribute: 'title' includesSubstring: 'hello' ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
   build
 ```
 ```css
@@ -225,15 +225,15 @@ Here is a small example that uses the pseudo-classes:
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector anchor link ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
   declareRuleSetFor: [:selector | selector anchor visited active]
-  with: [:style :constants | style color: constants >> #colors >> #green ];
+  with: [:style | style color: #green ];
   declareRuleSetFor: [:selector | selector anchor focus hover enabled]
-  with: [:style :constants | style color: constants >> #colors >> #green ];
+  with: [:style | style color: #green ];
   declareRuleSetFor: [:selector | (selector paragraph class: 'note') target disabled]
-  with: [:style :constants | style color: constants >> #colors >> #green ];
+  with: [:style | style color: #green ];
   declareRuleSetFor: [:selector | selector input checked ]
-  with: [:style :constants | style color: constants >> #colors >> #green ];
+  with: [:style | style color: #green ];
   build
 ```
 ```css
@@ -285,7 +285,7 @@ This selector is supported sending the message `not:`. Lets see an example:
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector button not: (selector havingAttribute: 'DISABLED') ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
   build
 ```
 ```css
@@ -304,7 +304,7 @@ The :root pseudo-class represents an element that is the root of the document. T
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector root ]
-  with: [:style :constants | style color: constants >> #colors >> #grey ];
+  with: [:style | style color: #grey ];
   build
 ```
 
@@ -319,11 +319,11 @@ Since version 1.1.0 the library supports an abstraction for this kind of formula
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector childAt: 3 n + 1 ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
   declareRuleSetFor: [:selector | selector childAt: 5 ]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
-  declareRuleSetFor: [:selector | selector childAt: CssConstants even]
-  with: [:style :constants | style color: constants >> #colors >> #blue ];
+  with: [:style | style color: #blue ];
+  declareRuleSetFor: [:selector | selector childAt: #even]
+  with: [:style | style color: #blue ];
   build
 ```
 ```css
@@ -374,7 +374,7 @@ This selector describes the contents of the first formatted line of an element.
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector paragraph firstLine ]
-  with: [:style :constants | style textTransform: constants >> #uppercase ];
+  with: [:style | style textTransform: #uppercase ];
   build
 ```
 ```css

--- a/docs/tutorial/Tutorial - Part III.md
+++ b/docs/tutorial/Tutorial - Part III.md
@@ -57,6 +57,8 @@ To use media queries in the library just send the message `declare:forMediaMatch
 The media query builder will match any media type by default. To specify a media type just send it the message `type:` with the corresponding media type. You can provide the following media types by keyword:
 `braille`, `embossed`, `handheld`, `print`, `projection`, `screen`, `speech`, `tty` and `tv`.
 
+To get the list of media query constants supported inspect `RenoirSt classPool at: #CssMediaQueryConstants`.
+
 The media query builder supports a variety of messages for additional conditions (called media features). Media features are used in expressions to describe requirements of the output device.
 
 The following media feature messages are supported:

--- a/docs/tutorial/Tutorial - Part III.md
+++ b/docs/tutorial/Tutorial - Part III.md
@@ -12,11 +12,11 @@ The library provides support for this feature by sending `beImportantDuring:` me
 ```smalltalk
 CascadingStyleSheetBuilder new
   declareRuleSetFor: [:selector | selector paragraph ]
-  with: [:style :constants |
+  with: [:style |
     style beImportantDuring: [:importantStyle |
       importantStyle
         textIndent: 1 em;
-        fontStyle: constants >> #italic
+        fontStyle: #italic
     ].
     style fontSize: 18 pt.
   ];
@@ -46,15 +46,15 @@ CascadingStyleSheetBuilder new
 	declare: [ :cssBuilder |
 		cssBuilder
 			declareRuleSetFor: [ :selector | selector id: #oop ]
-			with: [ :style :constants | style color: constants >> #colors >> #red ]
+			with: [ :style | style color: #red ]
 		]
-	forMediaMatching: [ :queryBuilder :constants | queryBuilder type: constants >> #print ];
+	forMediaMatching: [ :queryBuilder | queryBuilder type: #print ];
 	build
 ```
 
-To use media queries in the library just send the message `declare:forMediaMatching:` to the builder. The first closure is evaluated with an instance of a `CascadingStyleSheetBuilder` and the second one with a builder of media queries (and optionally constants access).
+To use media queries in the library just send the message `declare:forMediaMatching:` to the builder.  The first closure is evaluated with an instance of a `CascadingStyleSheetBuilder` and the second one with a builder of media queries.
 
-The media query builder will match any media type by default. To specify a media type just send it the message `type:` with the corresponding media type. The `constants` argument provides easy access to the following media types:
+The media query builder will match any media type by default. To specify a media type just send it the message `type:` with the corresponding media type. You can provide the following media types by keyword:
 `braille`, `embossed`, `handheld`, `print`, `projection`, `screen`, `speech`, `tty` and `tv`.
 
 The media query builder supports a variety of messages for additional conditions (called media features). Media features are used in expressions to describe requirements of the output device.
@@ -73,7 +73,7 @@ The following media feature messages are supported:
 	- `deviceHeight:`
 	- `minDeviceHeight:`
 	- `maxDeviceHeight:`
-- `orientation:` accepting `constants >> #portrait` or `constants >> #landscape`
+- `orientation:` accepting `#portrait` or `#landscape`
 - Accepting fractions as aspect ratios
 	- `aspectRatio:`
 	- `minAspectRatio:`
@@ -96,7 +96,7 @@ The following media feature messages are supported:
 	- `resolution:`
 	- `minResolution:`
 	- `maxResolution:`
-- `scan:` accepting `constants >> #progressive` or `constants >> #interlace`
+- `scan:` accepting `#progressive` or `#interlace`
 
 New units for resolutions are added using the `CssMeasure` abstraction. This kind of measures can be created sending the messages `dpi` (dots per inch), `dpcm` (dots per centimeter) or `dppx` (dots per pixel unit) to an integer or float.
 
@@ -106,11 +106,11 @@ CascadingStyleSheetBuilder new
 	declare: [ :cssBuilder |
 		cssBuilder
 			declareRuleSetFor: [ :selector | selector id: #oop ]
-			with: [ :style :constants | style color: constants >> #colors >> #red ]
+			with: [ :style | style color: #red ]
 		]
-	forMediaMatching: [ :queryBuilder :constants |
+	forMediaMatching: [ :queryBuilder |
 		queryBuilder
-			orientation: constants >> #landscape;
+			orientation: #landscape;
 			resolution: 300 dpi
 		];
 	build
@@ -183,11 +183,11 @@ Here's a more complex case showing this:
 ```smalltalk
 CascadingStyleSheetBuilder new
 	declareFontFaceRuleWith:
-		[ :style :constants |
+		[ :style |
 		style
 			fontFamily: 'MainText';
 			src: (CssExternalFontReference locatedAt: 'gentium.eat' asZnUrl relativeToStyleSheet);
-			src: (CssLocalFontReference toFontNamed: 'Gentium')	, (CssExternalFontReference locatedAt: 'gentium.woff' asZnUrl relativeToStyleSheet withFormat: constants woff);
+			src: (CssLocalFontReference toFontNamed: 'Gentium')	, (CssExternalFontReference locatedAt: 'gentium.woff' asZnUrl relativeToStyleSheet withFormat: #woff);
 			src: (CssExternalFontReference svgFontLocatedAt: 'fonts.svg' asZnUrl relativeToStyleSheet withId: 'simple') ];
 	build
 ```
@@ -237,7 +237,7 @@ To load this extensions you need to load in an image with Seaside already loaded
 ```smalltalk
 Metacello new
   baseline: 'RenoirSt';
-  repository: 'github://gcotelli/RenoirSt:v5/source';
+  repository: 'github://ba-st/RenoirSt:v5/source';
   load: 'Deployment-Seaside-Extensions'
 ```
 
@@ -246,8 +246,8 @@ or
 ```smalltalk
 Metacello new
   baseline: 'RenoirSt';
-  repository: 'github://gcotelli/RenoirSt:v5/source';
-  load: 'Deployment-Seaside-Extensions'
+  repository: 'github://ba-st/RenoirSt:v5/source';
+  load: 'Development-Seaside-Extensions'
 ```
 
 There's an integration job in the CI server, testing this specific configuration: [![Build Status](https://ci.inria.fr/pharo-contribution/buildStatus/icon?job=RenoirSt-SeasideExtensions)](https://ci.inria.fr/pharo-contribution/job/RenoirSt-SeasideExtensions/).
@@ -260,7 +260,7 @@ Using the new Metacello API it's easy to reference the library as a dependency f
 ...
 	spec
 		baseline: 'RenoirSt'
-		with: [ spec repository: 'github://gcotelli/RenoirSt:v5.0.0/source'];
+		with: [ spec repository: 'github://ba-st/RenoirSt:v5.0.0/source'];
 		import: 'RenoirSt'
 ```
 
@@ -272,7 +272,7 @@ you can also load specific groups, like the Seaside extensions or do pattern mat
 		baseline: 'RenoirSt'
 		with: [
 			spec
-				repository: 'github://gcotelli/RenoirSt:v5/source';
+				repository: 'github://ba-st/RenoirSt:v5/source';
 				loads: #('Deployment-Seaside-Extensions')];
 		import: 'RenoirSt'
 ```

--- a/source/RenoirSt-HTML-Tests/CssDeclarationBlockTest.extension.st
+++ b/source/RenoirSt-HTML-Tests/CssDeclarationBlockTest.extension.st
@@ -4,13 +4,9 @@ Extension { #name : #CssDeclarationBlockTest }
 CssDeclarationBlockTest >> testVendorPropertySupport [
 
 	| style |
-	style := CssDeclarationBlock new.
-	style vendorPropertyAt: 'border-end-color' put: CssConstants >> #colors >> #black.
 
-	self
-		assert: style printString
-		equals:
-			('{<n><t><1s>: <2s>;<n><t>-moz-<1s>: <2s>;<n><t>-webkit-<1s>: <2s>;<n><t>-o-<1s>: <2s>;<n><t>-ms-<1s>: <2s>;<n>}'
-				expandMacrosWith: 'border-end-color'
-				with: 'black')
+	style := CssDeclarationBlock new.
+	style vendorPropertyAt: 'border-end-color' put: #black.
+
+	self assert: style printString equals: ('{<n><t><1s>: <2s>;<n><t>-moz-<1s>: <2s>;<n><t>-webkit-<1s>: <2s>;<n><t>-o-<1s>: <2s>;<n><t>-ms-<1s>: <2s>;<n>}' expandMacrosWith: 'border-end-color' with: 'black')
 ]

--- a/source/RenoirSt-Seaside-Tests/CssDeclarationBlockInSeasideTest.class.st
+++ b/source/RenoirSt-Seaside-Tests/CssDeclarationBlockInSeasideTest.class.st
@@ -1,3 +1,6 @@
+"
+I'm a test case for testing RenoirSt extensions that are Seaside aware.
+"
 Class {
 	#name : #CssDeclarationBlockInSeasideTest,
 	#superclass : #TestCase,
@@ -26,16 +29,15 @@ CssDeclarationBlockInSeasideTest >> testInlineStyleRendering [
 		yourself.
 
 	self
-		assert: (builder render: [ :html | html div setInlineStyleTo: [ :style | style margin: 1 px ] ])
-			equals: '<div style="margin: 1px;"></div>';
+		assert: (builder render: [ :html | html div setStyleTo: [ :style | style margin: 1 px ] ]) equals: '<div style="margin: 1px;"></div>';
 		assert:
 			(builder
 				render: [ :html | 
 					html div
-						setInlineStyleTo: [ :style :constants | 
+						setStyleTo: [ :style | 
 							style
-								margin: constants >> #auto;
-								color: constants >> #colors >> #blue ] ])
+								margin: #auto;
+								color: #blue ] ])
 			equals: '<div style="margin: auto;color: blue;"></div>'
 ]
 

--- a/source/RenoirSt-Tests/CascadingStyleSheetBuilderTest.class.st
+++ b/source/RenoirSt-Tests/CascadingStyleSheetBuilderTest.class.st
@@ -21,20 +21,19 @@ CascadingStyleSheetBuilderTest >> testBuildingOnlyWithComments [
 
 { #category : #Tests }
 CascadingStyleSheetBuilderTest >> testBuildingSimpleStyleSheet [
-	
+
 	| builder |
+
 	builder := CascadingStyleSheetBuilder new.
 	builder
 		declareRuleSetFor: [ :selector | selector class: 'xxx' ]
 			with: [ :style | 
 			style
-				color: 'white';
+				color: #white;
 				margin: 12 pt ];
-		declareRuleSetFor: [ :selector | selector id: #oop ] with: [ :style | style color: 'red' ].
-	
-	self
-		assert: builder build printString
-		equals: '.xxx<n>{<n><t>color: white;<n><t>margin: 12pt;<n>}<n><n>#oop<n>{<n><t>color: red;<n>}' expandMacros
+		declareRuleSetFor: [ :selector | selector id: #oop ] with: [ :style | style color: #red ].
+
+	self assert: builder build printString equals: '.xxx<n>{<n><t>color: white;<n><t>margin: 12pt;<n>}<n><n>#oop<n>{<n><t>color: red;<n>}' expandMacros
 ]
 
 { #category : #Tests }
@@ -43,9 +42,7 @@ CascadingStyleSheetBuilderTest >> testBuildingSimpleStyleSheetUsingConstants [
 	| builder |
 
 	builder := CascadingStyleSheetBuilder new.
-	builder
-		declareRuleSetFor: [ :selector | selector class: 'xxx' ]
-		with: [ :style :constants | style fontSize: constants >> #auto ].
+	builder declareRuleSetFor: [ :selector | selector class: 'xxx' ] with: [ :style | style fontSize: #auto ].
 
 	self assert: builder build printString equals: '.xxx<n>{<n><t>font-size: auto;<n>}' expandMacros
 ]
@@ -54,8 +51,9 @@ CascadingStyleSheetBuilderTest >> testBuildingSimpleStyleSheetUsingConstants [
 CascadingStyleSheetBuilderTest >> testBuildingSimpleStyleSheetWithSomeComments [
 
 	| builder |
+
 	builder := CascadingStyleSheetBuilder new.
-	builder declareRuleSetFor: [ :selector | selector id: #oop ] with: [ :style | style color: 'red' ] andComment: 'Example CSS'.
+	builder declareRuleSetFor: [ :selector | selector id: #oop ] with: [ :style | style color: #red ] andComment: 'Example CSS'.
 
 	self assert: builder build printString equals: '/*Example CSS*/<n>#oop<n>{<n><t>color: red;<n>}' expandMacros
 ]
@@ -68,12 +66,9 @@ CascadingStyleSheetBuilderTest >> testBuildingStyleSheetWithMediaQuery [
 	builder := CascadingStyleSheetBuilder new.
 	builder
 		declareRuleSetFor: [ :selector | selector class: 'xxx' ] with: [ :style | style margin: 12 pt ];
-		declare: [ :cssBuilder | cssBuilder declareRuleSetFor: [ :selector | selector id: #oop ] with: [ :style | style color: 'red' ] ]
-			forMediaMatching: [ :queryBuilder :constants | queryBuilder type: constants >> #print ].
+		declare: [ :cssBuilder | cssBuilder declareRuleSetFor: [ :selector | selector id: #oop ] with: [ :style | style color: #red ] ] forMediaMatching: [ :queryBuilder | queryBuilder type: #print ].
 
-	self
-		assert: builder build printString
-		equals: '.xxx<n>{<n><t>margin: 12pt;<n>}<n><n>@media print<n>{<n><t>#oop<n><t>{<n><t><t>color: red;<n><t>}<n>}' expandMacros
+	self assert: builder build printString equals: '.xxx<n>{<n><t>margin: 12pt;<n>}<n><n>@media print<n>{<n><t>#oop<n><t>{<n><t><t>color: red;<n><t>}<n>}' expandMacros
 ]
 
 { #category : #Tests }
@@ -84,10 +79,7 @@ CascadingStyleSheetBuilderTest >> testBuildingStyleSheetWithMediaQueryWithoutCon
 	builder := CascadingStyleSheetBuilder new.
 	builder
 		declareRuleSetFor: [ :selector | selector class: 'xxx' ] with: [ :style | style margin: 12 pt ];
-		declare: [ :cssBuilder | cssBuilder declareRuleSetFor: [ :selector | selector id: #oop ] with: [ :style | style color: 'red' ] ]
-			forMediaMatching: [ :queryBuilder | queryBuilder width: 600 px ].
+		declare: [ :cssBuilder | cssBuilder declareRuleSetFor: [ :selector | selector id: #oop ] with: [ :style | style color: #red ] ] forMediaMatching: [ :queryBuilder | queryBuilder width: 600 px ].
 
-	self
-		assert: builder build printString
-		equals: '.xxx<n>{<n><t>margin: 12pt;<n>}<n><n>@media all and (width: 600px)<n>{<n><t>#oop<n><t>{<n><t><t>color: red;<n><t>}<n>}' expandMacros
+	self assert: builder build printString equals: '.xxx<n>{<n><t>margin: 12pt;<n>}<n><n>@media all and (width: 600px)<n>{<n><t>#oop<n><t>{<n><t><t>color: red;<n><t>}<n>}' expandMacros
 ]

--- a/source/RenoirSt-Tests/CssAttributeReferenceTest.class.st
+++ b/source/RenoirSt-Tests/CssAttributeReferenceTest.class.st
@@ -4,9 +4,6 @@ A CssAttributeReferenceTest is a test class for testing the behavior of CssAttri
 Class {
 	#name : #CssAttributeReferenceTest,
 	#superclass : #TestCase,
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Tests-Units'
 }
 
@@ -25,7 +22,7 @@ CssAttributeReferenceTest >> testAttributeReferenceWithType [
 
 	| attributeReference |
 
-	attributeReference := CssAttributeReference toAttributeNamed: 'length' ofType: CssConstants >> #units >> #fontSize.
+	attributeReference := CssAttributeReference toAttributeNamed: 'length' ofType: #fontSize.
 
 	self assert: attributeReference printString equals: 'attr(length em)'
 ]
@@ -35,7 +32,7 @@ CssAttributeReferenceTest >> testAttributeReferenceWithTypeAndFallback [
 
 	| attributeReference |
 
-	attributeReference := CssAttributeReference toAttributeNamed: 'length' ofType: CssConstants >> #units >> #fontSize withFallback: 10 px.
+	attributeReference := CssAttributeReference toAttributeNamed: 'length' ofType: #fontSize withFallback: 10 px.
 
 	self assert: attributeReference printString equals: 'attr(length em, 10px)'
 ]

--- a/source/RenoirSt-Tests/CssBoxShadowTest.class.st
+++ b/source/RenoirSt-Tests/CssBoxShadowTest.class.st
@@ -1,9 +1,9 @@
+"
+I'm a test case for CssBoxShadow
+"
 Class {
 	#name : #CssBoxShadowTest,
 	#superclass : #TestCase,
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Tests-Common'
 }
 
@@ -19,7 +19,7 @@ CssBoxShadowTest >> testBoxShadowSet [
 		verticalOffset: 2 px
 		blurRadius: 1 px
 		spreadDistance: 1 px
-		color: CssConstants >> #colors >> #white.
+		color: #white.
 
 	self assert: (insetShadow , shadow) printString equals: 'inset 1px 2px, 1px 2px 1px 1px white'
 ]
@@ -47,13 +47,13 @@ CssBoxShadowTest >> testBoxShadowWithBlurRadiusPrintString [
 CssBoxShadowTest >> testBoxShadowWithColorPrintString [
 
 	self
-		assert: (CssBoxShadow horizontalOffset: 64 px verticalOffset: 64 px color: CssConstants >> #colors >> #red) printString equals: '64px 64px red';
+		assert: (CssBoxShadow horizontalOffset: 64 px verticalOffset: 64 px color: #red) printString equals: '64px 64px red';
 		assert:
 			(CssBoxShadow
 				horizontalOffset: 64 px
 				verticalOffset: 64 px
 				blurRadius: 3 px
-				color: CssConstants >> #colors >> #red) printString
+				color: #red) printString
 			equals: '64px 64px 3px red';
 		assert:
 			(CssBoxShadow
@@ -61,7 +61,7 @@ CssBoxShadowTest >> testBoxShadowWithColorPrintString [
 				verticalOffset: 64 px
 				blurRadius: 3 px
 				spreadDistance: 8 px
-				color: CssConstants >> #colors >> #red) printString
+				color: #red) printString
 			equals: '64px 64px 3px 8px red'
 ]
 

--- a/source/RenoirSt-Tests/CssConstantsTest.class.st
+++ b/source/RenoirSt-Tests/CssConstantsTest.class.st
@@ -10,197 +10,202 @@ Class {
 	#category : #'RenoirSt-Tests-Common'
 }
 
+{ #category : #'private - asserting' }
+CssConstantsTest >> assertConstant: aSymbol equals: anExpectedValue [
+
+	self assert: CssConstants >> aSymbol equals: anExpectedValue
+]
+
 { #category : #Tests }
 CssConstantsTest >> testAttachmentProperties [
 
 	self
-		assert: CssConstants >> #fixed equals: 'fixed';
-		assert: CssConstants >> #scroll equals: 'scroll'
+		assertConstant: #fixed equals: 'fixed';
+		assertConstant: #scroll equals: 'scroll'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testBackgroundProperties [
 	
 	self
-		assert: CssConstants >> #round equals: 'round';
-		assert: CssConstants >> #space equals: 'space';
-		assert: CssConstants >> #local equals: 'local';
-		assert: CssConstants >> #borderBox equals: 'border-box';
-		assert: CssConstants >> #paddingBox equals: 'padding-box';
-		assert: CssConstants >> #contentBox equals: 'content-box';
-		assert: CssConstants >> #closestCorner equals: 'closest-corner';
-		assert: CssConstants >> #closestSide equals: 'closest-side';
-		assert: CssConstants >> #farthestCorner equals: 'farthest-corner';
-		assert: CssConstants >> #farthestSide equals: 'farthest-side'
+		assertConstant: #round equals: 'round';
+		assertConstant: #space equals: 'space';
+		assertConstant: #local equals: 'local';
+		assertConstant: #borderBox equals: 'border-box';
+		assertConstant: #paddingBox equals: 'padding-box';
+		assertConstant: #contentBox equals: 'content-box';
+		assertConstant: #closestCorner equals: 'closest-corner';
+		assertConstant: #closestSide equals: 'closest-side';
+		assertConstant: #farthestCorner equals: 'farthest-corner';
+		assertConstant: #farthestSide equals: 'farthest-side'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testBasicConstants [
 
 	self
-		assert: CssConstants >> #auto equals: 'auto';
-		assert: CssConstants >> #even equals: 'even';
-		assert: CssConstants >> #hide equals: 'hide';
-		assert: CssConstants >> #inherit equals: 'inherit';
-		assert: CssConstants >> #none equals: 'none';
-		assert: CssConstants >> #odd equals: 'odd';
-		assert: CssConstants >> #show equals: 'show';
-		assert: CssConstants >> #vertical equals: 'vertical';
-		assert: CssConstants >> #initial equals: 'initial';
-		assert: CssConstants >> #invert equals: 'invert'
+		assertConstant: #auto equals: 'auto';
+		assertConstant: #even equals: 'even';
+		assertConstant: #hide equals: 'hide';
+		assertConstant: #inherit equals: 'inherit';
+		assertConstant: #none equals: 'none';
+		assertConstant: #odd equals: 'odd';
+		assertConstant: #show equals: 'show';
+		assertConstant: #vertical equals: 'vertical';
+		assertConstant: #initial equals: 'initial';
+		assertConstant: #invert equals: 'invert'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testBorderProperties [
 
 	self
-		assert: CssConstants >> #fill equals: 'fill';
-		assert: CssConstants >> #stretch equals: 'stretch';
-		assert: CssConstants >> #collapse equals: 'collapse';
-		assert: CssConstants >> #dashed equals: 'dashed';
-		assert: CssConstants >> #dotted equals: 'dotted';
-		assert: CssConstants >> #double equals: 'double';
-		assert: CssConstants >> #groove equals: 'groove';
-		assert: CssConstants >> #inset equals: 'inset';
-		assert: CssConstants >> #medium equals: 'medium';
-		assert: CssConstants >> #outset equals: 'outset';
-		assert: CssConstants >> #ridge equals: 'ridge';
-		assert: CssConstants >> #separate equals: 'separate';
-		assert: CssConstants >> #solid equals: 'solid';
-		assert: CssConstants >> #thick equals: 'thick';
-		assert: CssConstants >> #thin equals: 'thin'
+		assertConstant: #fill equals: 'fill';
+		assertConstant: #stretch equals: 'stretch';
+		assertConstant: #collapse equals: 'collapse';
+		assertConstant: #dashed equals: 'dashed';
+		assertConstant: #dotted equals: 'dotted';
+		assertConstant: #double equals: 'double';
+		assertConstant: #groove equals: 'groove';
+		assertConstant: #inset equals: 'inset';
+		assertConstant: #medium equals: 'medium';
+		assertConstant: #outset equals: 'outset';
+		assertConstant: #ridge equals: 'ridge';
+		assertConstant: #separate equals: 'separate';
+		assertConstant: #solid equals: 'solid';
+		assertConstant: #thick equals: 'thick';
+		assertConstant: #thin equals: 'thin'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testCursors [
 
 	self
-		assert: CssConstants >> #crosshair equals: 'crosshair';
-		assert: CssConstants >> #default equals: 'default';
-		assert: CssConstants >> #help equals: 'help';
-		assert: CssConstants >> #move equals: 'move';
-		assert: CssConstants >> #notAllowed equals: 'not-allowed';
-		assert: CssConstants >> #pointer equals: 'pointer';
-		assert: CssConstants >> #progress equals: 'progress';
-		assert: CssConstants >> #text equals: 'text';
-		assert: CssConstants >> #wait equals: 'wait'
+		assertConstant: #crosshair equals: 'crosshair';
+		assertConstant: #default equals: 'default';
+		assertConstant: #help equals: 'help';
+		assertConstant: #move equals: 'move';
+		assertConstant: #notAllowed equals: 'not-allowed';
+		assertConstant: #pointer equals: 'pointer';
+		assertConstant: #progress equals: 'progress';
+		assertConstant: #text equals: 'text';
+		assertConstant: #wait equals: 'wait'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testDisplayConstants [
 
 	self
-		assert: CssConstants >> #inline equals: 'inline';
-		assert: CssConstants >> #inlineBlock equals: 'inline-block';
-		assert: CssConstants >> #inlineTable equals: 'inline-table';
-		assert: CssConstants >> #listItem equals: 'list-item';
-		assert: CssConstants >> #table equals: 'table';
-		assert: CssConstants >> #tableCaption equals: 'table-caption';
-		assert: CssConstants >> #tableCell equals: 'table-cell';
-		assert: CssConstants >> #tableColumn equals: 'table-column';
-		assert: CssConstants >> #tableColumnGroup equals: 'table-column-group';
-		assert: CssConstants >> #tableFooterGroup equals: 'table-footer-group';
-		assert: CssConstants >> #tableHeaderGroup equals: 'table-header-group';
-		assert: CssConstants >> #tableRow equals: 'table-row';
-		assert: CssConstants >> #tableRowGroup equals: 'table-row-group'
+		assertConstant: #inline equals: 'inline';
+		assertConstant: #inlineBlock equals: 'inline-block';
+		assertConstant: #inlineTable equals: 'inline-table';
+		assertConstant: #listItem equals: 'list-item';
+		assertConstant: #table equals: 'table';
+		assertConstant: #tableCaption equals: 'table-caption';
+		assertConstant: #tableCell equals: 'table-cell';
+		assertConstant: #tableColumn equals: 'table-column';
+		assertConstant: #tableColumnGroup equals: 'table-column-group';
+		assertConstant: #tableFooterGroup equals: 'table-footer-group';
+		assertConstant: #tableHeaderGroup equals: 'table-header-group';
+		assertConstant: #tableRow equals: 'table-row';
+		assertConstant: #tableRowGroup equals: 'table-row-group'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testFontConstants [
 
 	self
-		assert: CssConstants >> #bold equals: 'bold';
-		assert: CssConstants >> #bolder equals: 'bolder';
-		assert: CssConstants >> #caption equals: 'caption';
-		assert: CssConstants >> #icon equals: 'icon';
-		assert: CssConstants >> #lighter equals: 'lighter';
-		assert: CssConstants >> #menu equals: 'menu';
-		assert: CssConstants >> #messageBox equals: 'message-box';
-		assert: CssConstants >> #oblique equals: 'oblique';
-		assert: CssConstants >> #smallCaption equals: 'small-caption';
-		assert: CssConstants >> #statusBar equals: 'status-bar'
+		assertConstant: #bold equals: 'bold';
+		assertConstant: #bolder equals: 'bolder';
+		assertConstant: #caption equals: 'caption';
+		assertConstant: #icon equals: 'icon';
+		assertConstant: #lighter equals: 'lighter';
+		assertConstant: #menu equals: 'menu';
+		assertConstant: #messageBox equals: 'message-box';
+		assertConstant: #oblique equals: 'oblique';
+		assertConstant: #smallCaption equals: 'small-caption';
+		assertConstant: #statusBar equals: 'status-bar'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testGradientConstants [
 	
 	self
-		assert: CssConstants >> #closestSide equals: 'closest-side';
-		assert: CssConstants >> #farthestSide equals: 'farthest-side';
-		assert: CssConstants >> #closestCorner equals: 'closest-corner';
-		assert: CssConstants >> #farthestCorner equals: 'farthest-corner'
+		assertConstant: #closestSide equals: 'closest-side';
+		assertConstant: #farthestSide equals: 'farthest-side';
+		assertConstant: #closestCorner equals: 'closest-corner';
+		assertConstant: #farthestCorner equals: 'farthest-corner'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testListProperties [
 
 	self
-		assert: CssConstants >> #armenian equals: 'armenian';
-		assert: CssConstants >> #decimal equals: 'decimal';
-		assert: CssConstants >> #decimalLeadingZero equals: 'decimal-leading-zero';
-		assert: CssConstants >> #disc equals: 'disc';
-		assert: CssConstants >> #georgian equals: 'georgian';
-		assert: CssConstants >> #lowerGreek equals: 'lower-greek';
-		assert: CssConstants >> #lowerLatin equals: 'lower-latin';
-		assert: CssConstants >> #lowerRoman equals: 'lower-roman';
-		assert: CssConstants >> #outside equals: 'outside';
-		assert: CssConstants >> #square equals: 'square';
-		assert: CssConstants >> #upperAlpha equals: 'upper-alpha';
-		assert: CssConstants >> #upperLatin equals: 'upper-latin';
-		assert: CssConstants >> #upperRoman equals: 'upper-roman'
+		assertConstant: #armenian equals: 'armenian';
+		assertConstant: #decimal equals: 'decimal';
+		assertConstant: #decimalLeadingZero equals: 'decimal-leading-zero';
+		assertConstant: #disc equals: 'disc';
+		assertConstant: #georgian equals: 'georgian';
+		assertConstant: #lowerGreek equals: 'lower-greek';
+		assertConstant: #lowerLatin equals: 'lower-latin';
+		assertConstant: #lowerRoman equals: 'lower-roman';
+		assertConstant: #outside equals: 'outside';
+		assertConstant: #square equals: 'square';
+		assertConstant: #upperAlpha equals: 'upper-alpha';
+		assertConstant: #upperLatin equals: 'upper-latin';
+		assertConstant: #upperRoman equals: 'upper-roman'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testPositioningProperties [
 
 	self
-		assert: CssConstants >> #absolute equals: 'absolute';
-		assert: CssConstants >> #always equals: 'always';
-		assert: CssConstants >> #avoid equals: 'avoid';
-		assert: CssConstants >> #baseline equals: 'baseline';
-		assert: CssConstants >> #justify equals: 'justify';
-		assert: CssConstants >> #static equals: 'static';
-		assert: CssConstants >> #sub equals: 'sub';
-		assert: CssConstants >> #super equals: 'super';
-		assert: CssConstants >> #textBottom equals: 'text-bottom';
-		assert: CssConstants >> #textTop equals: 'text-top';
-		assert: CssConstants >> #visible equals: 'visible'
+		assertConstant: #absolute equals: 'absolute';
+		assertConstant: #always equals: 'always';
+		assertConstant: #avoid equals: 'avoid';
+		assertConstant: #baseline equals: 'baseline';
+		assertConstant: #justify equals: 'justify';
+		assertConstant: #static equals: 'static';
+		assertConstant: #sub equals: 'sub';
+		assertConstant: #super equals: 'super';
+		assertConstant: #textBottom equals: 'text-bottom';
+		assertConstant: #textTop equals: 'text-top';
+		assertConstant: #visible equals: 'visible'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testRepeatProperties [
 
 	self
-		assert: CssConstants >> #noRepeat equals: 'no-repeat';
-		assert: CssConstants >> #repeat equals: 'repeat';
-		assert: CssConstants >> #repeatX equals: 'repeat-x';
-		assert: CssConstants >> #repeatY equals: 'repeat-y'
+		assertConstant: #noRepeat equals: 'no-repeat';
+		assertConstant: #repeat equals: 'repeat';
+		assertConstant: #repeatX equals: 'repeat-x';
+		assertConstant: #repeatY equals: 'repeat-y'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testSizeConstants [
-	
-	self 
-		assert: CssConstants >> #cover equals: 'cover'
+
+	self assertConstant: #cover equals: 'cover'
 ]
 
 { #category : #Tests }
 CssConstantsTest >> testTextConstants [
 
 	self
-		assert: CssConstants >> #blink equals: 'blink';
-		assert: CssConstants >> #filled equals: 'filled';
-		assert: CssConstants >> #open equals: 'open';
-		assert: CssConstants >> #dot equals: 'dot';
-		assert: CssConstants >> #doubleCircle equals: 'double-circle';
-		assert: CssConstants >> #lineThrough equals: 'line-through';
-		assert: CssConstants >> #lowercase equals: 'lowercase';
-		assert: CssConstants >> #triangle equals: 'triangle';
-		assert: CssConstants >> #sesame equals: 'sesame';
-		assert: CssConstants >> #over equals: 'over';
-		assert: CssConstants >> #overline equals: 'overline';
-		assert: CssConstants >> #pre equals: 'pre';
-		assert: CssConstants >> #preLine equals: 'pre-line';
-		assert: CssConstants >> #preWrap equals: 'pre-wrap';
-		assert: CssConstants >> #uppercase equals: 'uppercase'
+		assertConstant: #blink equals: 'blink';
+		assertConstant: #filled equals: 'filled';
+		assertConstant: #open equals: 'open';
+		assertConstant: #dot equals: 'dot';
+		assertConstant: #doubleCircle equals: 'double-circle';
+		assertConstant: #lineThrough equals: 'line-through';
+		assertConstant: #lowercase equals: 'lowercase';
+		assertConstant: #triangle equals: 'triangle';
+		assertConstant: #sesame equals: 'sesame';
+		assertConstant: #over equals: 'over';
+		assertConstant: #overline equals: 'overline';
+		assertConstant: #pre equals: 'pre';
+		assertConstant: #preLine equals: 'pre-line';
+		assertConstant: #preWrap equals: 'pre-wrap';
+		assertConstant: #uppercase equals: 'uppercase'
 ]

--- a/source/RenoirSt-Tests/CssDeclarationBlockTest.class.st
+++ b/source/RenoirSt-Tests/CssDeclarationBlockTest.class.st
@@ -4,9 +4,6 @@ A CssDeclarationBlockTest is a test class for testing the behavior of CssDeclara
 Class {
 	#name : #CssDeclarationBlockTest,
 	#superclass : #TestCase,
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Tests-Common'
 }
 
@@ -14,54 +11,55 @@ Class {
 CssDeclarationBlockTest >> assert: aBlockClosure rendersProperty: aPropertyName withValue: anExpectedValue [
 
 	| style |
-	style := CssDeclarationBlock new.
-	aBlockClosure cull: style cull: CssConstants.
 
-	self assert: style printString equals: ('{<n><t><1s>: <2s>;<n>}' expandMacrosWith: aPropertyName with: anExpectedValue)
+	style := CssDeclarationBlock new.
+	aBlockClosure cull: style.
+
+	self
+		assert: style printString
+		equals: ('{<n><t><1s>: <2s>;<n>}' expandMacrosWith: aPropertyName with: anExpectedValue)
 ]
 
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintInlined [
 
 	| style |
+
 	style := CssDeclarationBlock new.
 	style
-		borderWidth: CssConstants >> #thin;
-		borderStyle: CssConstants >> #dashed;
+		borderWidth: #thin;
+		borderStyle: #dashed;
 		borderRadius: 4 px.
 
-	self
-		assert: (String streamContents: [ :stream | style printInlinedOn: stream ])
-		equals: 'border-width: thin;border-style: dashed;border-radius: 4px;'
+	self assert: (String streamContents: [ :stream | style printInlinedOn: stream ]) equals: 'border-width: thin;border-style: dashed;border-radius: 4px;'
 ]
 
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintStringOfBackgroundProperties [
 
 	self
-		assert: [ :style :constants | style background: constants >> #colors >> #blue ] rendersProperty: 'background' withValue: 'blue';
-		assert: [ :style :constants | style backgroundAttachment: constants >> #scroll ] rendersProperty: 'background-attachment' withValue: 'scroll';
-		assert: [ :style :constants | style backgroundColor: constants >> #colors >> #red ] rendersProperty: 'background-color' withValue: 'red';
+		assert: [ :style | style background: #blue ] rendersProperty: 'background' withValue: 'blue';
+		assert: [ :style | style backgroundAttachment: #scroll ] rendersProperty: 'background-attachment' withValue: 'scroll';
+		assert: [ :style | style backgroundColor: #yellowGreen ] rendersProperty: 'background-color' withValue: 'yellowgreen';
 		assert: [ :style | style backgroundImage: 'logo.png' ] rendersProperty: 'background-image' withValue: 'logo.png';
 		assert: [ :style | style backgroundPosition: {0 percent. 0 percent} ] rendersProperty: 'background-position' withValue: '0% 0%';
-		assert: [ :style :constants | style backgroundRepeat: constants >> #repeat ] rendersProperty: 'background-repeat' withValue: 'repeat';
-		assert: [ :style :constants | style backgroundSize: constants >> #contain ] rendersProperty: 'background-size' withValue: 'contain';
-		assert: [ :style :constants | style backgroundClip: constants >> #borderBox ] rendersProperty: 'background-clip' withValue: 'border-box';
-		assert: [ :style :constants | style backgroundOrigin: constants >> #borderBox ] rendersProperty: 'background-origin' withValue: 'border-box'
+		assert: [ :style | style backgroundRepeat: #repeat ] rendersProperty: 'background-repeat' withValue: 'repeat';
+		assert: [ :style | style backgroundSize: #contain ] rendersProperty: 'background-size' withValue: 'contain';
+		assert: [ :style | style backgroundClip: #borderBox ] rendersProperty: 'background-clip' withValue: 'border-box';
+		assert: [ :style | style backgroundOrigin: #borderBox ] rendersProperty: 'background-origin' withValue: 'border-box'
 ]
 
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintStringOfBorderImageProperties [
 
 	self
-		assert: [ :style :constants | style borderImageSource: constants  >> #none ] rendersProperty: 'border-image-source' withValue: 'none';
+		assert: [ :style | style borderImageSource: #none ] rendersProperty: 'border-image-source' withValue: 'none';
 		assert: [ :style | style borderImageSlice: 50 percent ] rendersProperty: 'border-image-slice' withValue: '50%';
 		assert: [ :style | style borderImageWidth: 2 px ] rendersProperty: 'border-image-width' withValue: '2px';
 		assert: [ :style | style borderImageOutset: 3 px ] rendersProperty: 'border-image-outset' withValue: '3px';
-		assert: [ :style :constants | style borderImageRepeat: constants  >> #round ] rendersProperty: 'border-image-repeat' withValue: 'round';
-		assert: [ :style :constants | style borderImage: constants  >> #none ] rendersProperty: 'border-image' withValue: 'none';
-		assert:
-				[ :style :constants | 
+		assert: [ :style | style borderImageRepeat: #round ] rendersProperty: 'border-image-repeat' withValue: 'round';
+		assert: [ :style | style borderImage: #none ] rendersProperty: 'border-image' withValue: 'none';
+		assert: [ :style | 
 			style
 				boxShadow:
 					(CssBoxShadow
@@ -69,7 +67,7 @@ CssDeclarationBlockTest >> testPrintStringOfBorderImageProperties [
 						verticalOffset: 10 px
 						blurRadius: 10 px
 						spreadDistance: 35 px
-						color: constants >> #colors >> #blue) ]
+						color: #blue) ]
 			rendersProperty: 'box-shadow'
 			withValue: '10px 10px 10px 35px blue'
 ]
@@ -78,37 +76,37 @@ CssDeclarationBlockTest >> testPrintStringOfBorderImageProperties [
 CssDeclarationBlockTest >> testPrintStringOfBorderProperties [
 
 	self
-		assert: [ :style :constants | style border: { constants  >> #thin. constants  >> #dashed. constants  >> #colors >> #royalBlue }  ] rendersProperty: 'border' withValue: 'thin dashed royalblue';
-		assert: [ :style :constants | style borderBottom: { constants  >> #thin. constants  >> #dashed. constants  >> #colors >> #royalBlue }  ] rendersProperty: 'border-bottom' withValue: 'thin dashed royalblue';
-		assert: [ :style :constants | style borderTop: { constants  >> #thin. constants  >> #dashed. constants  >> #colors >> #royalBlue }  ] rendersProperty: 'border-top' withValue: 'thin dashed royalblue';
-		assert: [ :style :constants | style borderRight: { constants  >> #thin. constants  >> #dashed. constants  >> #colors >> #royalBlue }  ] rendersProperty: 'border-right' withValue: 'thin dashed royalblue';
-		assert: [ :style :constants | style borderLeft: { constants  >> #thin. constants  >> #dashed. constants  >> #colors >> #royalBlue }  ] rendersProperty: 'border-left' withValue: 'thin dashed royalblue';
-		assert: [ :style :constants | style borderColor: constants  >> #colors >> #royalBlue ] rendersProperty: 'border-color' withValue: 'royalblue';
-		assert: [ :style :constants | style borderWidth:  constants  >> #thin. ] rendersProperty: 'border-width' withValue: 'thin';
-		assert: [ :style :constants | style borderStyle: constants  >> #dashed. ] rendersProperty: 'border-style' withValue: 'dashed';
-		assert: [ :style :constants | style borderTopColor: constants  >> #colors >> #royalBlue ] rendersProperty: 'border-top-color' withValue: 'royalblue';
-		assert: [ :style :constants | style borderTopWidth:  constants  >> #thin. ] rendersProperty: 'border-top-width' withValue: 'thin';
-		assert: [ :style :constants | style borderTopStyle: constants  >> #dashed. ] rendersProperty: 'border-top-style' withValue: 'dashed';
-		assert: [ :style :constants | style borderBottomColor: constants  >> #colors >> #royalBlue ] rendersProperty: 'border-bottom-color' withValue: 'royalblue';
-		assert: [ :style :constants | style borderBottomWidth:  constants  >> #thin. ] rendersProperty: 'border-bottom-width' withValue: 'thin';
-		assert: [ :style :constants | style borderBottomStyle: constants  >> #dashed. ] rendersProperty: 'border-bottom-style' withValue: 'dashed';
-		assert: [ :style :constants | style borderLeftColor: constants  >> #colors >> #royalBlue ] rendersProperty: 'border-left-color' withValue: 'royalblue';
-		assert: [ :style :constants | style borderLeftWidth:  constants  >> #thin. ] rendersProperty: 'border-left-width' withValue: 'thin';
-		assert: [ :style :constants | style borderLeftStyle: constants  >> #dashed. ] rendersProperty: 'border-left-style' withValue: 'dashed';
-		assert: [ :style :constants | style borderRightColor: constants  >> #colors >> #royalBlue ] rendersProperty: 'border-right-color' withValue: 'royalblue';
-		assert: [ :style :constants | style borderRightWidth:  constants  >> #thin. ] rendersProperty: 'border-right-width' withValue: 'thin';
-		assert: [ :style :constants | style borderRightStyle: constants  >> #dashed. ] rendersProperty: 'border-right-style' withValue: 'dashed';
+		assert: [ :style | style border: #(#thin #dashed #royalBlue) ] rendersProperty: 'border' withValue: 'thin dashed royalblue';
+		assert: [ :style | style borderBottom: #(#thin #dashed #royalBlue) ] rendersProperty: 'border-bottom' withValue: 'thin dashed royalblue';
+		assert: [ :style | style borderTop: #(#thin #dashed #royalBlue) ] rendersProperty: 'border-top' withValue: 'thin dashed royalblue';
+		assert: [ :style | style borderRight: #(#thin #dashed #royalBlue) ] rendersProperty: 'border-right' withValue: 'thin dashed royalblue';
+		assert: [ :style | style borderLeft: #(#thin #dashed #royalBlue) ] rendersProperty: 'border-left' withValue: 'thin dashed royalblue';
+		assert: [ :style | style borderColor: #royalBlue ] rendersProperty: 'border-color' withValue: 'royalblue';
+		assert: [ :style | style borderWidth: #thin ] rendersProperty: 'border-width' withValue: 'thin';
+		assert: [ :style | style borderStyle: #dashed ] rendersProperty: 'border-style' withValue: 'dashed';
+		assert: [ :style | style borderTopColor: #royalBlue ] rendersProperty: 'border-top-color' withValue: 'royalblue';
+		assert: [ :style | style borderTopWidth: #thin ] rendersProperty: 'border-top-width' withValue: 'thin';
+		assert: [ :style | style borderTopStyle: #dashed ] rendersProperty: 'border-top-style' withValue: 'dashed';
+		assert: [ :style | style borderBottomColor: #royalBlue ] rendersProperty: 'border-bottom-color' withValue: 'royalblue';
+		assert: [ :style | style borderBottomWidth: #thin ] rendersProperty: 'border-bottom-width' withValue: 'thin';
+		assert: [ :style | style borderBottomStyle: #dashed ] rendersProperty: 'border-bottom-style' withValue: 'dashed';
+		assert: [ :style | style borderLeftColor: #royalBlue ] rendersProperty: 'border-left-color' withValue: 'royalblue';
+		assert: [ :style | style borderLeftWidth: #thin ] rendersProperty: 'border-left-width' withValue: 'thin';
+		assert: [ :style | style borderLeftStyle: #dashed ] rendersProperty: 'border-left-style' withValue: 'dashed';
+		assert: [ :style | style borderRightColor: #royalBlue ] rendersProperty: 'border-right-color' withValue: 'royalblue';
+		assert: [ :style | style borderRightWidth: #thin ] rendersProperty: 'border-right-width' withValue: 'thin';
+		assert: [ :style | style borderRightStyle: #dashed ] rendersProperty: 'border-right-style' withValue: 'dashed';
 		assert: [ :style | style borderRadius: 4 px ] rendersProperty: 'border-radius' withValue: '4px';
-		assert: [ :style | style borderTopLeftRadius: 1 px] rendersProperty: 'border-top-left-radius' withValue: '1px';
-		assert: [ :style | style borderBottomLeftRadius: 1 px] rendersProperty: 'border-bottom-left-radius' withValue: '1px';
-		assert: [ :style | style borderTopRightRadius: 1 px] rendersProperty: 'border-top-right-radius' withValue: '1px';
-		assert: [ :style | style borderBottomRightRadius: 1 px] rendersProperty: 'border-bottom-right-radius' withValue: '1px'
+		assert: [ :style | style borderTopLeftRadius: 1 px ] rendersProperty: 'border-top-left-radius' withValue: '1px';
+		assert: [ :style | style borderBottomLeftRadius: 1 px ] rendersProperty: 'border-bottom-left-radius' withValue: '1px';
+		assert: [ :style | style borderTopRightRadius: 1 px ] rendersProperty: 'border-top-right-radius' withValue: '1px';
+		assert: [ :style | style borderBottomRightRadius: 1 px ] rendersProperty: 'border-bottom-right-radius' withValue: '1px'
 ]
 
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintStringOfBoxProperties [
 
-	self 
+	self
 		assert: [ :style | style height: 5 cm ] rendersProperty: 'height' withValue: '5cm';
 		assert: [ :style | style maxHeight: 5 cm ] rendersProperty: 'max-height' withValue: '5cm';
 		assert: [ :style | style minHeight: 5 cm ] rendersProperty: 'min-height' withValue: '5cm';
@@ -116,8 +114,8 @@ CssDeclarationBlockTest >> testPrintStringOfBoxProperties [
 		assert: [ :style | style maxWidth: 5 cm ] rendersProperty: 'max-width' withValue: '5cm';
 		assert: [ :style | style minWidth: 5 cm ] rendersProperty: 'min-width' withValue: '5cm';
 		assert: [ :style | style lineHeight: 1.2 ] rendersProperty: 'line-height' withValue: '1.2';
-		assert: [ :style :constants | style verticalAlign: constants  >> #middle ] rendersProperty: 'vertical-align' withValue: 'middle';
-		assert: [ :style :constants | style resize: constants  >> #none ] rendersProperty: 'resize' withValue: 'none'
+		assert: [ :style | style verticalAlign: #middle ] rendersProperty: 'vertical-align' withValue: 'middle';
+		assert: [ :style | style resize: #none ] rendersProperty: 'resize' withValue: 'none'
 ]
 
 { #category : #Tests }
@@ -125,7 +123,7 @@ CssDeclarationBlockTest >> testPrintStringOfColorProperties [
 
 	self
 		assert: [ :style | style opacity: 0 ] rendersProperty: 'opacity' withValue: '0';
-		assert: [ :style :constants | style color: constants >> #colors >> #yellow ] rendersProperty: 'color' withValue: 'yellow'
+		assert: [ :style | style color: #yellow ] rendersProperty: 'color' withValue: 'yellow'
 ]
 
 { #category : #Tests }
@@ -137,32 +135,32 @@ CssDeclarationBlockTest >> testPrintStringOfEmptyDeclarationBlock [
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintStringOfFontProperties [
 
-	self 
+	self
 		assert: [ :style | style font: 14 pt ] rendersProperty: 'font' withValue: '14pt';
 		assert: [ :style | style fontSize: 14 pt ] rendersProperty: 'font-size' withValue: '14pt';
 		assert: [ :style | style fontSizeAdjust: 0.5 ] rendersProperty: 'font-size-adjust' withValue: '0.5';
-		assert: [ :style :constants | style fontFamily: constants >> #serif ] rendersProperty: 'font-family' withValue: 'serif';
-		assert: [ :style :constants | style fontStyle: constants >> #italic ] rendersProperty: 'font-style' withValue: 'italic';
-		assert: [ :style :constants | style fontVariant: constants >> #smallCaps ] rendersProperty: 'font-variant' withValue: 'small-caps';
-		assert: [ :style :constants | style fontWeight: constants >> #bolder ] rendersProperty: 'font-weight' withValue: 'bolder';
-		assert: [ :style :constants | style color: constants >> #colors >> #goldenrod ] rendersProperty: 'color' withValue: 'goldenrod';
-		assert: [ :style :constants | style fontStretch: constants >> #ultraCondensed ] rendersProperty: 'font-stretch' withValue: 'ultra-condensed';
-		assert: [ :style :constants | style fontSynthesis: {constants >> #weight . constants >> #style}] rendersProperty: 'font-synthesis' withValue: 'weight style';
-		assert: [ :style :constants | style fontKerning: constants >> #auto ] rendersProperty: 'font-kerning' withValue: 'auto'
+		assert: [ :style | style fontFamily: #sansSerif ] rendersProperty: 'font-family' withValue: 'sans-serif';
+		assert: [ :style | style fontStyle: #italic ] rendersProperty: 'font-style' withValue: 'italic';
+		assert: [ :style | style fontVariant: #smallCaps ] rendersProperty: 'font-variant' withValue: 'small-caps';
+		assert: [ :style | style fontWeight: #bolder ] rendersProperty: 'font-weight' withValue: 'bolder';
+		assert: [ :style | style color: #goldenrod ] rendersProperty: 'color' withValue: 'goldenrod';
+		assert: [ :style | style fontStretch: #ultraCondensed ] rendersProperty: 'font-stretch' withValue: 'ultra-condensed';
+		assert: [ :style | style fontSynthesis: #(#weight #style) ] rendersProperty: 'font-synthesis' withValue: 'weight style';
+		assert: [ :style | style fontKerning: #auto ] rendersProperty: 'font-kerning' withValue: 'auto'
 ]
 
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintStringOfGeneratedContentProperties [
 
-	self 
+	self
 		assert: [ :style | style content: '"hello"' ] rendersProperty: 'content' withValue: '"hello"';
 		assert: [ :style | style counterIncrement: 'chapter' ] rendersProperty: 'counter-increment' withValue: 'chapter';
 		assert: [ :style | style counterReset: 'chapter' ] rendersProperty: 'counter-reset' withValue: 'chapter';
-		assert: [ :style :constants | style listStyle: constants  >> #lowerAlpha ] rendersProperty: 'list-style' withValue: 'lower-alpha';
-		assert: [ :style :constants | style listStyleType: constants  >> #circle ] rendersProperty: 'list-style-type' withValue: 'circle';
-		assert: [ :style :constants | style listStyleImage: constants  >> #none ] rendersProperty: 'list-style-image' withValue: 'none';
-		assert: [ :style :constants | style listStylePosition: constants  >> #inside ] rendersProperty: 'list-style-position' withValue: 'inside';
-		assert: [ :style | style quotes: {'"<"' .'">"'} ] rendersProperty: 'quotes' withValue: '"<" ">"'
+		assert: [ :style | style listStyle: #lowerAlpha ] rendersProperty: 'list-style' withValue: 'lower-alpha';
+		assert: [ :style | style listStyleType: #circle ] rendersProperty: 'list-style-type' withValue: 'circle';
+		assert: [ :style | style listStyleImage: #none ] rendersProperty: 'list-style-image' withValue: 'none';
+		assert: [ :style | style listStylePosition: #inside ] rendersProperty: 'list-style-position' withValue: 'inside';
+		assert: [ :style | style quotes: {'"<"' . '">"'} ] rendersProperty: 'quotes' withValue: '"<" ">"'
 ]
 
 { #category : #Tests }
@@ -180,18 +178,12 @@ CssDeclarationBlockTest >> testPrintStringOfMarginProperties [
 CssDeclarationBlockTest >> testPrintStringOfMoreFontProperties [
 
 	self
-		assert: [ :style :constants | 
-			style
-				fontVariantLigatures:
-					{(constants >> #commonLigatures).
-					(constants >> #noDiscretionaryLigatures).
-					(constants >> #historicalLigatures).
-					(constants >> #contextual)} ]
+		assert: [ :style | style fontVariantLigatures: #(#commonLigatures #noDiscretionaryLigatures #historicalLigatures #contextual) ]
 			rendersProperty: 'font-variant-ligatures'
 			withValue: 'common-ligatures no-discretionary-ligatures historical-ligatures contextual';
-		assert: [ :style :constants | style fontVariantPosition: constants >> #sub ] rendersProperty: 'font-variant-position' withValue: 'sub';
-		assert: [ :style :constants | style fontVariantCaps: constants >> #smallCaps ] rendersProperty: 'font-variant-caps' withValue: 'small-caps';
-		assert: [ :style :constants | style fontVariantNumeric: constants >> #ordinal ] rendersProperty: 'font-variant-numeric' withValue: 'ordinal'
+		assert: [ :style | style fontVariantPosition: #sub ] rendersProperty: 'font-variant-position' withValue: 'sub';
+		assert: [ :style | style fontVariantCaps: #smallCaps ] rendersProperty: 'font-variant-caps' withValue: 'small-caps';
+		assert: [ :style | style fontVariantNumeric: #ordinal ] rendersProperty: 'font-variant-numeric' withValue: 'ordinal'
 ]
 
 { #category : #Tests }
@@ -231,52 +223,52 @@ CssDeclarationBlockTest >> testPrintStringOfPaddingProperties [
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintStringOfTableProperties [
 
-	self 
-		assert: [ :style :constants | style borderCollapse: constants  >> #collapse ] rendersProperty: 'border-collapse' withValue: 'collapse';
+	self
+		assert: [ :style | style borderCollapse: #collapse ] rendersProperty: 'border-collapse' withValue: 'collapse';
 		assert: [ :style | style borderSpacing: 15 pt ] rendersProperty: 'border-spacing' withValue: '15pt';
-		assert: [ :style :constants | style captionSide:  constants  >> #bottom ] rendersProperty: 'caption-side' withValue: 'bottom';
-		assert: [ :style :constants | style emptyCells:  constants  >> #hide ] rendersProperty: 'empty-cells' withValue: 'hide';
-		assert: [ :style :constants | style tableLayout:  constants  >> #fixed ] rendersProperty: 'table-layout' withValue: 'fixed'
+		assert: [ :style | style captionSide: #bottom ] rendersProperty: 'caption-side' withValue: 'bottom';
+		assert: [ :style | style emptyCells: #hide ] rendersProperty: 'empty-cells' withValue: 'hide';
+		assert: [ :style | style tableLayout: #fixed ] rendersProperty: 'table-layout' withValue: 'fixed'
 ]
 
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintStringOfTextDecorationProperties [
 
-	self 
-		assert: [ :style :constants | style textDecorationLine: constants  >> #underline ] rendersProperty: 'text-decoration-line' withValue: 'underline';
-		assert: [ :style :constants | style textDecorationColor: constants >> #colors >> #red ] rendersProperty: 'text-decoration-color' withValue: 'red';
-		assert: [ :style :constants | style textDecorationStyle: constants  >> #solid ] rendersProperty: 'text-decoration-style' withValue: 'solid';
-		assert: [ :style :constants | style textUnderlinePosition: constants  >> #under ] rendersProperty: 'text-underline-position' withValue: 'under';
-		assert: [ :style :constants | style textEmphasisStyle: constants  >> #filled ] rendersProperty: 'text-emphasis-style' withValue: 'filled';
-		assert: [ :style :constants | style textEmphasisColor: constants >> #colors >> #red ] rendersProperty: 'text-emphasis-color' withValue: 'red';
-		assert: [ :style :constants | style textEmphasisPosition: constants  >> #over ] rendersProperty: 'text-emphasis-position' withValue: 'over';
-		assert: [ :style :constants | style textEmphasis: constants  >> #filled ] rendersProperty: 'text-emphasis' withValue: 'filled';
-		assert: [ :style :constants | style textShadow: constants  >> #none ] rendersProperty: 'text-shadow' withValue: 'none'
+	self
+		assert: [ :style | style textDecorationLine: #underline ] rendersProperty: 'text-decoration-line' withValue: 'underline';
+		assert: [ :style | style textDecorationColor: #red ] rendersProperty: 'text-decoration-color' withValue: 'red';
+		assert: [ :style | style textDecorationStyle: #solid ] rendersProperty: 'text-decoration-style' withValue: 'solid';
+		assert: [ :style | style textUnderlinePosition: #under ] rendersProperty: 'text-underline-position' withValue: 'under';
+		assert: [ :style | style textEmphasisStyle: #filled ] rendersProperty: 'text-emphasis-style' withValue: 'filled';
+		assert: [ :style | style textEmphasisColor: #red ] rendersProperty: 'text-emphasis-color' withValue: 'red';
+		assert: [ :style | style textEmphasisPosition: #over ] rendersProperty: 'text-emphasis-position' withValue: 'over';
+		assert: [ :style | style textEmphasis: #filled ] rendersProperty: 'text-emphasis' withValue: 'filled';
+		assert: [ :style | style textShadow: #none ] rendersProperty: 'text-shadow' withValue: 'none'
 ]
 
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintStringOfTextProperties [
 
 	self
-		assert: [ :style :constants | style letterSpacing: constants  >> #normal ] rendersProperty: 'letter-spacing' withValue: 'normal';
-		assert: [ :style :constants | style textAlign: constants  >> #center ] rendersProperty: 'text-align' withValue: 'center';
-		assert: [ :style :constants | style textDecoration: constants  >> #underline ] rendersProperty: 'text-decoration' withValue: 'underline';
+		assert: [ :style | style letterSpacing: #normal ] rendersProperty: 'letter-spacing' withValue: 'normal';
+		assert: [ :style | style textAlign: #center ] rendersProperty: 'text-align' withValue: 'center';
+		assert: [ :style | style textDecoration: #underline ] rendersProperty: 'text-decoration' withValue: 'underline';
 		assert: [ :style | style textIndent: 5 percent ] rendersProperty: 'text-indent' withValue: '5%';
-		assert: [ :style :constants | style textTransform: constants  >> #capitalize ] rendersProperty: 'text-transform' withValue: 'capitalize';
-		assert: [ :style :constants | style whiteSpace: constants  >> #nowrap ] rendersProperty: 'white-space' withValue: 'nowrap';
-		assert: [ :style :constants | style wordSpacing: constants  >> #normal ] rendersProperty: 'word-spacing' withValue: 'normal';
-		assert: [ :style :constants | style wordWrap: constants  >> #breakWord ] rendersProperty: 'word-wrap' withValue: 'break-word';
-		assert: [ :style :constants | style textOverflow: constants  >> #ellipsis ] rendersProperty: 'text-overflow' withValue: 'ellipsis'
+		assert: [ :style | style textTransform: #capitalize ] rendersProperty: 'text-transform' withValue: 'capitalize';
+		assert: [ :style | style whiteSpace: #nowrap ] rendersProperty: 'white-space' withValue: 'nowrap';
+		assert: [ :style | style wordSpacing: #normal ] rendersProperty: 'word-spacing' withValue: 'normal';
+		assert: [ :style | style wordWrap: #breakWord ] rendersProperty: 'word-wrap' withValue: 'break-word';
+		assert: [ :style | style textOverflow: #ellipsis ] rendersProperty: 'text-overflow' withValue: 'ellipsis'
 ]
 
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintStringOfUIProperties [
 
-	self 
-		assert: [ :style :constants | style cursor: constants  >> #auto ] rendersProperty: 'cursor' withValue: 'auto';
-		assert: [ :style :constants | style outline: constants  >> #dotted ] rendersProperty: 'outline' withValue: 'dotted';
-		assert: [ :style :constants | style outlineColor: constants >> #colors >> #black ] rendersProperty: 'outline-color' withValue: 'black';
-		assert: [ :style :constants | style outlineStyle: constants  >> #dotted ] rendersProperty: 'outline-style' withValue: 'dotted';
+	self
+		assert: [ :style | style cursor: #auto ] rendersProperty: 'cursor' withValue: 'auto';
+		assert: [ :style | style outline: #dotted ] rendersProperty: 'outline' withValue: 'dotted';
+		assert: [ :style | style outlineColor: #black ] rendersProperty: 'outline-color' withValue: 'black';
+		assert: [ :style | style outlineStyle: #dotted ] rendersProperty: 'outline-style' withValue: 'dotted';
 		assert: [ :style | style outlineWidth: 2 px ] rendersProperty: 'outline-width' withValue: '2px'
 ]
 
@@ -284,29 +276,28 @@ CssDeclarationBlockTest >> testPrintStringOfUIProperties [
 CssDeclarationBlockTest >> testPrintStringOfVisualEffectProperties [
 
 	self
-		assert: [ :style :constants | style clip: constants  >> #auto ] rendersProperty: 'clip' withValue: 'auto';
-		assert: [ :style :constants | style overflow: constants  >> #hidden ] rendersProperty: 'overflow' withValue: 'hidden';
-		assert: [ :style :constants | style visibility: constants  >> #collapse ] rendersProperty: 'visibility' withValue: 'collapse';
-		assert: [ :style :constants | style overflowY: constants  >> #hidden ] rendersProperty: 'overflow-y' withValue: 'hidden';
-		assert: [ :style :constants | style overflowX: constants  >> #hidden ] rendersProperty: 'overflow-x' withValue: 'hidden'
+		assert: [ :style | style clip: #auto ] rendersProperty: 'clip' withValue: 'auto';
+		assert: [ :style | style overflow: #hidden ] rendersProperty: 'overflow' withValue: 'hidden';
+		assert: [ :style | style visibility: #collapse ] rendersProperty: 'visibility' withValue: 'collapse';
+		assert: [ :style | style overflowY: #hidden ] rendersProperty: 'overflow-y' withValue: 'hidden';
+		assert: [ :style | style overflowX: #hidden ] rendersProperty: 'overflow-x' withValue: 'hidden'
 ]
 
 { #category : #Tests }
 CssDeclarationBlockTest >> testPrintStringOfVisualFormattingProperties [
 
-	self 
+	self
 		assert: [ :style | style bottom: 4 cm ] rendersProperty: 'bottom' withValue: '4cm';
-		assert: [ :style :constants | style clear: constants  >> #both ] rendersProperty: 'clear' withValue: 'both';
+		assert: [ :style | style clear: #both ] rendersProperty: 'clear' withValue: 'both';
 		assert: [ :style | style direction: 'ltr' ] rendersProperty: 'direction' withValue: 'ltr';
-		assert: [ :style :constants | style display: constants  >> #block ] rendersProperty: 'display' withValue: 'block';
-		assert: [ :style :constants | style float: constants  >> #left ] rendersProperty: 'float' withValue: 'left';
+		assert: [ :style | style display: #block ] rendersProperty: 'display' withValue: 'block';
+		assert: [ :style | style float: #left ] rendersProperty: 'float' withValue: 'left';
 		assert: [ :style | style left: 4 cm ] rendersProperty: 'left' withValue: '4cm';
-		assert: [ :style :constants | style position: constants  >> #relative ] rendersProperty: 'position' withValue: 'relative';
+		assert: [ :style | style position: #relative ] rendersProperty: 'position' withValue: 'relative';
 		assert: [ :style | style right: 4 cm ] rendersProperty: 'right' withValue: '4cm';
 		assert: [ :style | style top: 4 cm ] rendersProperty: 'top' withValue: '4cm';
-		assert: [ :style :constants | style unicodeBidi: constants  >> #normal ] rendersProperty: 'unicode-bidi' withValue: 'normal';
+		assert: [ :style | style unicodeBidi: #normal ] rendersProperty: 'unicode-bidi' withValue: 'normal';
 		assert: [ :style | style zIndex: 4 ] rendersProperty: 'z-index' withValue: '4'
-		
 ]
 
 { #category : #Tests }
@@ -315,7 +306,7 @@ CssDeclarationBlockTest >> testPrintStringWithSeveralDeclarations [
 	| declarationBlock |
 	declarationBlock := CssDeclarationBlock new.
 	declarationBlock
-		color: 'red';
+		color: #red;
 		margin: {1 px. 3 pc. 4 pt. 50 percent}.
 
 	self assert: declarationBlock printString equals: ('{<n><t>color: red;<n><t>margin: 1px 3pc 4pt 50<1s>;<n>}' expandMacrosWith: '%')

--- a/source/RenoirSt-Tests/CssFontConstantsTest.class.st
+++ b/source/RenoirSt-Tests/CssFontConstantsTest.class.st
@@ -10,105 +10,111 @@ Class {
 	#category : #'RenoirSt-Tests-Fonts'
 }
 
+{ #category : #'private - asserting' }
+CssFontConstantsTest >> assertConstant: aSymbol equals: anExpectedValue [
+
+	self assert: CssConstants >> aSymbol equals: anExpectedValue
+]
+
 { #category : #Tests }
 CssFontConstantsTest >> testFontFormatConstants [
 
 	self
-		assert: CssConstants >> #woff equals: 'woff';
-		assert: CssConstants >> #truetype equals: 'truetype';
-		assert: CssConstants >> #opentype equals: 'opentype';
-		assert: CssConstants >> #embeddedOpentype equals: 'embedded-opentype';
-		assert: CssConstants >> #svg equals: 'svg'
+		assertConstant: #woff equals: 'woff';
+		assertConstant: #truetype equals: 'truetype';
+		assertConstant: #opentype equals: 'opentype';
+		assertConstant: #embeddedOpentype equals: 'embedded-opentype';
+		assertConstant: #svg equals: 'svg'
 ]
 
 { #category : #Tests }
 CssFontConstantsTest >> testFontSizeConstants [
 
 	self
-		assert: CssConstants >> #xxSmall equals: 'xx-small';
-		assert: CssConstants >> #xSmall equals: 'x-small';
-		assert: CssConstants >> #small equals: 'small';
-		assert: CssConstants >> #medium equals: 'medium';
-		assert: CssConstants >> #large equals: 'large';
-		assert: CssConstants >> #xLarge equals: 'x-large';
-		assert: CssConstants >> #xxLarge equals: 'xx-large';
-		assert: CssConstants >> #larger equals: 'larger';
-		assert: CssConstants >> #smaller equals: 'smaller'
+		assertConstant: #xxSmall equals: 'xx-small';
+		assertConstant: #xSmall equals: 'x-small';
+		assertConstant: #small equals: 'small';
+		assertConstant: #medium equals: 'medium';
+		assertConstant: #large equals: 'large';
+		assertConstant: #xLarge equals: 'x-large';
+		assertConstant: #xxLarge equals: 'xx-large';
+		assertConstant: #larger equals: 'larger';
+		assertConstant: #smaller equals: 'smaller'
 ]
 
 { #category : #Tests }
 CssFontConstantsTest >> testFontStretchConstants [
 
 	self
-		assert: CssConstants >> #ultraCondensed equals: 'ultra-condensed';
-		assert: CssConstants >> #extraCondensed equals: 'extra-condensed';
-		assert: CssConstants >> #condensed equals: 'condensed';
-		assert: CssConstants >> #semiCondensed equals: 'semi-condensed';
-		assert: CssConstants >> #normal equals: 'normal';
-		assert: CssConstants >> #semiExpanded equals: 'semi-expanded';
-		assert: CssConstants >> #extraExpanded equals: 'extra-expanded';
-		assert: CssConstants >> #expanded equals: 'expanded';
-		assert: CssConstants >> #ultraExpanded equals: 'ultra-expanded'
+		assertConstant: #ultraCondensed equals: 'ultra-condensed';
+		assertConstant: #extraCondensed equals: 'extra-condensed';
+		assertConstant: #condensed equals: 'condensed';
+		assertConstant: #semiCondensed equals: 'semi-condensed';
+		assertConstant: #normal equals: 'normal';
+		assertConstant: #semiExpanded equals: 'semi-expanded';
+		assertConstant: #extraExpanded equals: 'extra-expanded';
+		assertConstant: #expanded equals: 'expanded';
+		assertConstant: #ultraExpanded equals: 'ultra-expanded'
 ]
 
 { #category : #Tests }
 CssFontConstantsTest >> testFontVariantCapsConstants [
 
 	self
-		assert: CssConstants >> #smallCaps equals: 'small-caps';
-		assert: CssConstants >> #allSmallCaps equals: 'all-small-caps';
-		assert: CssConstants >> #petiteCaps equals: 'petite-caps';
-		assert: CssConstants >> #allPetiteCaps equals: 'all-petite-caps';
-		assert: CssConstants >> #unicase equals: 'unicase';
-		assert: CssConstants >> #titlingCaps equals: 'titling-caps';
-		assert: CssConstants >> #normal equals: 'normal'
+		assertConstant: #smallCaps equals: 'small-caps';
+		assertConstant: #allSmallCaps equals: 'all-small-caps';
+		assertConstant: #petiteCaps equals: 'petite-caps';
+		assertConstant: #allPetiteCaps equals: 'all-petite-caps';
+		assertConstant: #unicase equals: 'unicase';
+		assertConstant: #titlingCaps equals: 'titling-caps';
+		assertConstant: #normal equals: 'normal'
 ]
 
 { #category : #Tests }
 CssFontConstantsTest >> testFontVariantLigaturesConstants [
 
 	self
-		assert: CssConstants >> #commonLigatures  equals: 'common-ligatures';
-		assert: CssConstants >> #noCommonLigatures equals: 'no-common-ligatures';
-		assert: CssConstants >> #discretionaryLigatures equals: 'discretionary-ligatures';
-		assert: CssConstants >> #noDiscretionaryLigatures  equals: 'no-discretionary-ligatures';
-		assert: CssConstants >> #historicalLigatures equals: 'historical-ligatures';
-		assert: CssConstants >> #noHistoricalLigatures equals: 'no-historical-ligatures';
-		assert: CssConstants >> #contextual equals: 'contextual';
-		assert: CssConstants >> #noContextual equals: 'no-contextual'
+		assertConstant: #commonLigatures  equals: 'common-ligatures';
+		assertConstant: #noCommonLigatures equals: 'no-common-ligatures';
+		assertConstant: #discretionaryLigatures equals: 'discretionary-ligatures';
+		assertConstant: #noDiscretionaryLigatures  equals: 'no-discretionary-ligatures';
+		assertConstant: #historicalLigatures equals: 'historical-ligatures';
+		assertConstant: #noHistoricalLigatures equals: 'no-historical-ligatures';
+		assertConstant: #contextual equals: 'contextual';
+		assertConstant: #noContextual equals: 'no-contextual'
 ]
 
 { #category : #Tests }
 CssFontConstantsTest >> testFontVariantNumericConstants [
 
 	self
-		assert: CssConstants >> #ordinal equals: 'ordinal';
-		assert: CssConstants >> #slashedZero equals: 'slashed-zero';
-		assert: CssConstants >> #liningNums equals: 'lining-nums';
-		assert: CssConstants >> #oldstyleNums equals: 'oldstyle-nums';
-		assert: CssConstants >> #proportionalNums equals: 'proportional-nums';
-		assert: CssConstants >> #tabularNums equals: 'tabular-nums';
-		assert: CssConstants >> #diagonalFractions equals: 'diagonal-fractions';
-		assert: CssConstants >> #stackedFractions equals: 'stacked-fractions';
-		assert: CssConstants >> #normal equals: 'normal'
+		assertConstant: #ordinal equals: 'ordinal';
+		assertConstant: #slashedZero equals: 'slashed-zero';
+		assertConstant: #liningNums equals: 'lining-nums';
+		assertConstant: #oldstyleNums equals: 'oldstyle-nums';
+		assertConstant: #proportionalNums equals: 'proportional-nums';
+		assertConstant: #tabularNums equals: 'tabular-nums';
+		assertConstant: #diagonalFractions equals: 'diagonal-fractions';
+		assertConstant: #stackedFractions equals: 'stacked-fractions';
+		assertConstant: #normal equals: 'normal'
 ]
 
 { #category : #Tests }
 CssFontConstantsTest >> testFontVariantPositionConstants [
 
 	self
-		assert: CssConstants >> #sub  equals: 'sub';
-		assert: CssConstants >> #super equals: 'super';
-		assert: CssConstants >> #normal equals: 'normal'
+		assertConstant: #sub  equals: 'sub';
+		assertConstant: #super equals: 'super';
+		assertConstant: #normal equals: 'normal'
 ]
 
 { #category : #Tests }
 CssFontConstantsTest >> testGenericFontFamiliesAccessors [
 
 	self
-		assert: CssConstants >> #serif equals: 'serif';
-		assert: CssConstants >> #sansSerif equals: 'sans-serif';
-		assert: CssConstants >> #cursive equals: 'cursive';
-		assert: CssConstants >> #fantasy equals: 'fantasy';
-		assert: CssConstants >> #monospace equals: 'monospace'
+		assertConstant: #serif equals: 'serif';
+		assertConstant: #sansSerif equals: 'sans-serif';
+		assertConstant: #cursive equals: 'cursive';
+		assertConstant: #fantasy equals: 'fantasy';
+		assertConstant: #monospace equals: 'monospace'
 ]

--- a/source/RenoirSt-Tests/CssFontFaceRuleTest.class.st
+++ b/source/RenoirSt-Tests/CssFontFaceRuleTest.class.st
@@ -1,3 +1,6 @@
+"
+I'm a test case for CssFontFaceRule
+"
 Class {
 	#name : #CssFontFaceRuleTest,
 	#superclass : #TestCase,
@@ -11,16 +14,15 @@ CssFontFaceRuleTest >> testComplexFontFaceRule [
 
 	builder := CascadingStyleSheetBuilder new.
 	builder
-		declareFontFaceRuleWith: [ :style :constants | 
+		declareFontFaceRuleWith: [ :style | 
 			style
 				fontFamily: 'MainText';
 				src: (CssExternalFontReference locatedAt: 'gentium.eat' asZnUrl relativeToStyleSheet);
-				src: (CssLocalFontReference toFontNamed: 'Gentium') , (CssExternalFontReference locatedAt: 'gentium.woff' asZnUrl relativeToStyleSheet withFormat: constants >> #woff);
+				src: (CssLocalFontReference toFontNamed: 'Gentium') , (CssExternalFontReference locatedAt: 'gentium.woff' asZnUrl relativeToStyleSheet withFormat: #woff);
 				src: (CssExternalFontReference svgFontLocatedAt: 'fonts.svg' asZnUrl relativeToStyleSheet withId: 'simple') ].
 	self
 		assert: builder build printString
-		equals:
-			'@font-face<n>{<n><t>font-family: MainText;<n><t>src: url("gentium.eat");<n><t>src: local(Gentium), url("gentium.woff") format("woff");<n><t>src: url("fonts.svg#simple") format("svg");<n>}' expandMacros
+		equals: '@font-face<n>{<n><t>font-family: MainText;<n><t>src: url("gentium.eat");<n><t>src: local(Gentium), url("gentium.woff") format("woff");<n><t>src: url("fonts.svg#simple") format("svg");<n>}' expandMacros
 ]
 
 { #category : #Tests }

--- a/source/RenoirSt-Tests/CssLinearGradientTest.class.st
+++ b/source/RenoirSt-Tests/CssLinearGradientTest.class.st
@@ -4,9 +4,6 @@ A CssLinearGradientTest is a test class for testing the behavior of CssLinearGra
 Class {
 	#name : #CssLinearGradientTest,
 	#superclass : #TestCase,
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Tests-Colors'
 }
 
@@ -14,8 +11,8 @@ Class {
 CssLinearGradientTest >> testGradientWithAngleDirectionSpecified [
 
 	| gradient |
-	
-	gradient := CssLinearGradient rotated: 45 deg fading: { CssConstants >> #colors >> #white. CssConstants >> #colors >> #red. CssConstants >> #colors >> #white }.
+
+	gradient := CssLinearGradient rotated: 45 deg fading: #(#white #red #white).
 	self assert: gradient printString equals: 'linear-gradient(45deg, white, red, white)'
 ]
 
@@ -24,7 +21,7 @@ CssLinearGradientTest >> testGradientWithColorStops [
 
 	| gradient |
 	
-	gradient := CssLinearGradient fading: { CssConstants >> #colors >> #white. (CssColorStop for: CssConstants >> #colors >> #red at: 20 percent) }.
+	gradient := CssLinearGradient fading: { #white. (CssColorStop for: #red at: 20 percent) }.
 	self assert: gradient printString equals: 'linear-gradient(white, red 20%)'
 ]
 
@@ -32,15 +29,11 @@ CssLinearGradientTest >> testGradientWithColorStops [
 CssLinearGradientTest >> testGradientWithNamedDirectionSpecified [
 
 	| gradient |
-	
-	gradient := CssLinearGradient
-		to: CssConstants >> #bottom
-		fading: {CssConstants >> #colors >> #white. CssConstants >> #colors >> #red}.
+
+	gradient := CssLinearGradient to: #bottom fading: #(#white #red).
 	self assert: gradient printString equals: 'linear-gradient(to bottom, white, red)'.
 
-	gradient := CssLinearGradient
-		to: {CssConstants >>#top. CssConstants >>#right}
-		fading: {CssConstants >> #colors >> #white. CssConstants >> #colors >> #red}.
+	gradient := CssLinearGradient to: #(#top #right) fading: #(#white #red).
 	self assert: gradient printString equals: 'linear-gradient(to top right, white, red)'
 ]
 
@@ -48,20 +41,18 @@ CssLinearGradientTest >> testGradientWithNamedDirectionSpecified [
 CssLinearGradientTest >> testGradientWithNoDirectionSpecified [
 
 	| gradient |
-	
-	gradient := CssLinearGradient fading: { CssConstants >> #colors >> #white. CssConstants >> #colors >> #red }.
+
+	gradient := CssLinearGradient fading: #(#white #red).
 	self assert: gradient printString equals: 'linear-gradient(white, red)'
 ]
 
 { #category : #Tests }
 CssLinearGradientTest >> testRepeatingGradientWithNoDirectionSpecified [
-	
+
 	| gradient |
-	gradient := CssLinearGradient
-		fading:
-			{CssConstants >> #colors >> #white.
-			CssConstants >> #colors >> #red}.
+
+	gradient := CssLinearGradient fading: #(#white #red).
 	gradient beRepeating.
-	
+
 	self assert: gradient printString equals: 'repeating-linear-gradient(white, red)'
 ]

--- a/source/RenoirSt-Tests/CssMediaQueryRuleBuilderTest.class.st
+++ b/source/RenoirSt-Tests/CssMediaQueryRuleBuilderTest.class.st
@@ -4,19 +4,17 @@ A CssMediaQueryRuleBuilderTest is a test class for testing the behavior of CssMe
 Class {
 	#name : #CssMediaQueryRuleBuilderTest,
 	#superclass : #TestCase,
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Tests-MediaQueries'
 }
 
 { #category : #Tests }
 CssMediaQueryRuleBuilderTest >> testComplexCaseBuilding [
-	
+
 	| builder |
+
 	builder := CssMediaQueryRuleBuilder new.
 	builder
-		type: CssMediaQueryConstants >> #print;
+		type: #print;
 		width: 300 px;
 		minWidth: 100 px;
 		maxWidth: 500 px;
@@ -29,7 +27,7 @@ CssMediaQueryRuleBuilderTest >> testComplexCaseBuilding [
 		deviceWidth: 100 px;
 		minDeviceWidth: 10 px;
 		maxDeviceWidth: 400 px;
-		orientation: CssMediaQueryConstants >> #landscape;
+		orientation: #landscape;
 		aspectRatio: 16 / 9;
 		minAspecRatio: 16 / 9;
 		maxAspectRatio: 16 / 9;
@@ -43,7 +41,7 @@ CssMediaQueryRuleBuilderTest >> testComplexCaseBuilding [
 		minMonochrome: 1;
 		maxMonochrome: 3;
 		resolution: 72 dpi;
-		scan: CssMediaQueryConstants >> #progressive;
+		scan: #progressive;
 		grid: 1.
 
 	self
@@ -57,8 +55,11 @@ CssMediaQueryRuleBuilderTest >> testComplexCaseBuilding [
 CssMediaQueryRuleBuilderTest >> testSimpleBuilding [
 
 	| builder |
-	builder := CssMediaQueryRuleBuilder new.
-	builder orientation: CssMediaQueryConstants >> #portrait.
 
-	self assert: builder build printString equals: '@media all and (orientation: portrait)<n>{<n><t><n>}' expandMacros
+	builder := CssMediaQueryRuleBuilder new.
+	builder orientation: #portrait.
+
+	self
+		assert: builder build printString
+		equals: '@media all and (orientation: portrait)<n>{<n><t><n>}' expandMacros
 ]

--- a/source/RenoirSt-Tests/CssMediaQueryRuleTest.class.st
+++ b/source/RenoirSt-Tests/CssMediaQueryRuleTest.class.st
@@ -4,9 +4,6 @@ A CssMediaQueryRuleTest is a test class for testing the behavior of CssMediaQuer
 Class {
 	#name : #CssMediaQueryRuleTest,
 	#superclass : #TestCase,
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Tests-MediaQueries'
 }
 
@@ -16,7 +13,7 @@ CssMediaQueryRuleTest >> testPrintStringOfSimpleMediaQuery [
 	| styleSheet mediaQuery |
 
 	styleSheet := CascadingStyleSheet withAll: #().
-	mediaQuery := CssMediaQueryRule ofType: CssMediaQueryConstants >> #screen enabling: styleSheet.
+	mediaQuery := CssMediaQueryRule ofType: #screen enabling: styleSheet.
 
 	self assert: mediaQuery printString equals: '@media screen<n>{<n><t><n>}' expandMacros
 ]
@@ -28,13 +25,11 @@ CssMediaQueryRuleTest >> testPrintStringWithExpressions [
 
 	styleSheet := CascadingStyleSheet withAll: #().
 	mediaQuery := CssMediaQueryRule
-		ofType: CssMediaQueryConstants >> #screen
+		ofType: #screen
 		conforming:
 			{(CssMediaQueryExpression forFeatureNamed: 'color').
-			(CssMediaQueryExpression forFeatureNamed: 'orientation' withValue: 'landscape')}
+			(CssMediaQueryExpression forFeatureNamed: 'orientation' withValue: #landscape)}
 		enabling: styleSheet.
 
-	self
-		assert: mediaQuery printString
-		equals: '@media screen and (color) and (orientation: landscape)<n>{<n><t><n>}' expandMacros
+	self assert: mediaQuery printString equals: '@media screen and (color) and (orientation: landscape)<n>{<n><t><n>}' expandMacros
 ]

--- a/source/RenoirSt-Tests/CssPseudoClassSelectorTest.class.st
+++ b/source/RenoirSt-Tests/CssPseudoClassSelectorTest.class.st
@@ -4,9 +4,6 @@ A CssPseudoClassSelectorTest is a test class for testing the behavior of CssPseu
 Class {
 	#name : #CssPseudoClassSelectorTest,
 	#superclass : #TestCase,
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Tests-Selectors'
 }
 

--- a/source/RenoirSt-Tests/CssPseudoClassSelectorTest.class.st
+++ b/source/RenoirSt-Tests/CssPseudoClassSelectorTest.class.st
@@ -131,8 +131,8 @@ CssPseudoClassSelectorTest >> testPrintStringOfStructuralPseudoClassesUsingEvenA
 	baseSelector := CssUniversalSelector explicit.
 
 	self
-		assert: (CssPseudoClassSelector childAt: CssConstants >> #even on: baseSelector) printString equals: '*:nth-child(even)';
-		assert: (CssPseudoClassSelector siblingOfTypeAt: CssConstants >> #odd on: baseSelector) printString equals: '*:nth-of-type(odd)'
+		assert: (CssPseudoClassSelector childAt: #even on: baseSelector) printString equals: '*:nth-child(even)';
+		assert: (CssPseudoClassSelector siblingOfTypeAt: #odd on: baseSelector) printString equals: '*:nth-of-type(odd)'
 ]
 
 { #category : #Tests }

--- a/source/RenoirSt-Tests/CssRadialGradientTest.class.st
+++ b/source/RenoirSt-Tests/CssRadialGradientTest.class.st
@@ -4,9 +4,6 @@ A CssRadialGradientTest is a test class for testing the behavior of CssRadialGra
 Class {
 	#name : #CssRadialGradientTest,
 	#superclass : #TestCase,
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Tests-Colors'
 }
 

--- a/source/RenoirSt-Tests/CssRadialGradientTest.class.st
+++ b/source/RenoirSt-Tests/CssRadialGradientTest.class.st
@@ -15,12 +15,7 @@ CssRadialGradientTest >> testCircleGradientPositioned [
 
 	| gradient |
 
-	gradient := CssRadialGradient
-		circular: 5 em
-		at: CssConstants >> #center
-		fading:
-			{CssConstants >> #colors >> #white.
-			CssConstants >> #colors >> #red}.
+	gradient := CssRadialGradient circular: 5 em at: #center fading: #(#white #red).
 	self assert: gradient printString equals: 'radial-gradient(5em circle at center, white, red)'
 ]
 
@@ -28,8 +23,8 @@ CssRadialGradientTest >> testCircleGradientPositioned [
 CssRadialGradientTest >> testCircleGradientSpecified [
 
 	| gradient |
-	
-	gradient := CssRadialGradient circular: 5 em fading: { CssConstants >> #colors >> #white. CssConstants >> #colors >> #red }.
+
+	gradient := CssRadialGradient circular: 5 em fading: #(white red).
 	self assert: gradient printString equals: 'radial-gradient(5em circle, white, red)'
 ]
 
@@ -38,7 +33,7 @@ CssRadialGradientTest >> testEllipseGradient [
 
 	| gradient |
 	
-	gradient := CssRadialGradient elliptical: {5 em. 3 em} fading: { CssConstants >> #colors >> #white. CssConstants >> #colors >> #red }.
+	gradient := CssRadialGradient elliptical: {5 em. 3 em} fading: #(white red).
 	self assert: gradient printString equals: 'radial-gradient(5em 3em ellipse, white, red)'
 ]
 
@@ -47,7 +42,7 @@ CssRadialGradientTest >> testEllipseGradientPositioned [
 
 	| gradient |
 	
-	gradient := CssRadialGradient elliptical: {5 em. 3 em} at: { 5px . 30 px} fading: { CssConstants >> #colors >> #white. CssConstants >> #colors >> #red }.
+	gradient := CssRadialGradient elliptical: {5 em. 3 em} at: { 5px . 30 px} fading: #(#white #red).
 	self assert: gradient printString equals: 'radial-gradient(5em 3em ellipse at 5px 30px, white, red)'
 ]
 
@@ -55,8 +50,8 @@ CssRadialGradientTest >> testEllipseGradientPositioned [
 CssRadialGradientTest >> testGradientWithNoShapeSpecified [
 
 	| gradient |
-	
-	gradient := CssRadialGradient fading: { CssConstants >> #colors >> #white. CssConstants >> #colors >> #red }.
+
+	gradient := CssRadialGradient fading: #(#white #red).
 	self assert: gradient printString equals: 'radial-gradient(white, red)'
 ]
 
@@ -64,8 +59,8 @@ CssRadialGradientTest >> testGradientWithNoShapeSpecified [
 CssRadialGradientTest >> testRepeatingGradient [
 
 	| gradient |
-	
-	gradient := CssRadialGradient fading: { CssConstants >> #colors >> #white. CssConstants >> #colors >> #red }.
+
+	gradient := CssRadialGradient fading: #(white red).
 	gradient beRepeating.
 	self assert: gradient printString equals: 'repeating-radial-gradient(white, red)'
 ]

--- a/source/RenoirSt-Tests/CssToggleTest.class.st
+++ b/source/RenoirSt-Tests/CssToggleTest.class.st
@@ -13,11 +13,5 @@ Class {
 { #category : #Tests }
 CssToggleTest >> testPrintString [
 
-	self
-		assert:
-			(CssToggle
-				cyclingOver:
-					{CssConstants >> #italic.
-					CssConstants >> #normal}) printString
-		equals: 'toggle(italic, normal)'
+	self assert: (CssToggle cyclingOver: #(#italic #normal)) printString equals: 'toggle(italic, normal)'
 ]

--- a/source/RenoirSt-Tests/CssToggleTest.class.st
+++ b/source/RenoirSt-Tests/CssToggleTest.class.st
@@ -4,9 +4,6 @@ A CssTogleTest is a test class for testing the behavior of CssTogle
 Class {
 	#name : #CssToggleTest,
 	#superclass : #TestCase,
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Tests-Common'
 }
 

--- a/source/RenoirSt/CascadingStyleSheetBuilder.class.st
+++ b/source/RenoirSt/CascadingStyleSheetBuilder.class.st
@@ -7,9 +7,6 @@ Class {
 	#instVars : [
 		'statements'
 	],
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Common'
 }
 
@@ -40,7 +37,7 @@ CascadingStyleSheetBuilder >> declare: aSubStyleSheetBlock forMediaMatching: aMe
 	aSubStyleSheetBlock value: styleSheetBuilder.
 
 	mediaQueryBuilder := CssMediaQueryRuleBuilder new.
-	aMediaQueryBlock cull: mediaQueryBuilder cull: CssMediaQueryConstants.
+	aMediaQueryBlock cull: mediaQueryBuilder.
 
 	mediaQueryBuilder useStyleSheet: styleSheetBuilder build.
 	self addStatement: mediaQueryBuilder build
@@ -49,9 +46,10 @@ CascadingStyleSheetBuilder >> declare: aSubStyleSheetBlock forMediaMatching: aMe
 { #category : #Configuring }
 CascadingStyleSheetBuilder >> declareFontFaceRuleWith: aDeclarationAction [
 
-	|  declarationBlock |
+	| declarationBlock |
+
 	declarationBlock := CssDeclarationBlock new.
-	aDeclarationAction cull: declarationBlock cull: CssConstants.
+	aDeclarationAction cull: declarationBlock.
 	self addStatement: (CssRuleSet selector: '@font-face' declarations: declarationBlock)
 ]
 
@@ -65,9 +63,10 @@ CascadingStyleSheetBuilder >> declareRuleSetFor: aSelectorBlock with: aDeclarati
 CascadingStyleSheetBuilder >> declareRuleSetFor: aSelectorBlock with: aDeclarationAction andComment: aComment [
 
 	| selector declarationBlock |
+
 	selector := aSelectorBlock cull: CssUniversalSelector implicit.
 	declarationBlock := CssDeclarationBlock new.
-	aDeclarationAction cull: declarationBlock cull: CssConstants.
+	aDeclarationAction cull: declarationBlock.
 	self addStatement: (CssRuleSet selector: selector declarations: declarationBlock comment: aComment)
 ]
 

--- a/source/RenoirSt/CssAttributeReference.class.st
+++ b/source/RenoirSt/CssAttributeReference.class.st
@@ -48,6 +48,12 @@ CssAttributeReference class >> toStringAttributeNamed: aString withFallback: aFa
 ]
 
 { #category : #private }
+CssAttributeReference >> asTypeOrUnit: aCssTypeOrNamedUnit [
+
+	^ CssConstants >> #units at: aCssTypeOrNamedUnit ifAbsent: [ aCssTypeOrNamedUnit ]
+]
+
+{ #category : #private }
 CssAttributeReference >> cssFunctionParametersContentOn: aStream [
 	attributeName cssContentOn: aStream.
 	aStream space.
@@ -61,8 +67,9 @@ CssAttributeReference >> functionName [
 ]
 
 { #category : #'initialize - release' }
-CssAttributeReference >> initializeWithAttributeNamed: aString withType: aCssTypeOrUnit withFallback: aCssFallback [
+CssAttributeReference >> initializeWithAttributeNamed: aString withType: aCssTypeOrNamedUnit withFallback: aCssFallback [
+
 	attributeName := aString.
-	typeOrUnit := aCssTypeOrUnit.
+	typeOrUnit := self asTypeOrUnit: aCssTypeOrNamedUnit.
 	fallback := aCssFallback
 ]

--- a/source/RenoirSt/CssBoxShadow.class.st
+++ b/source/RenoirSt/CssBoxShadow.class.st
@@ -7,9 +7,6 @@ Class {
 	#instVars : [
 		'components'
 	],
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Common'
 }
 
@@ -33,14 +30,14 @@ CssBoxShadow class >> horizontalOffset: horizontalOffsetLength verticalOffset: v
 ]
 
 { #category : #'Instance Creation' }
-CssBoxShadow class >> horizontalOffset: horizontalOffsetLength verticalOffset: verticalOffsetLength blurRadius: blurRadiusLength color: color [
+CssBoxShadow class >> horizontalOffset: horizontalOffsetLength verticalOffset: verticalOffsetLength blurRadius: blurRadiusLength color: colorOrNamedConstant [
 
 	^ self
 		withAll:
 			{horizontalOffsetLength.
 			verticalOffsetLength.
 			blurRadiusLength.
-			color}
+			(self lookupColor: colorOrNamedConstant)}
 ]
 
 { #category : #'Instance Creation' }
@@ -55,7 +52,7 @@ CssBoxShadow class >> horizontalOffset: horizontalOffsetLength verticalOffset: v
 ]
 
 { #category : #'Instance Creation' }
-CssBoxShadow class >> horizontalOffset: horizontalOffsetLength verticalOffset: verticalOffsetLength blurRadius: blurRadiusLength spreadDistance: spreadDistanceLength color: color [
+CssBoxShadow class >> horizontalOffset: horizontalOffsetLength verticalOffset: verticalOffsetLength blurRadius: blurRadiusLength spreadDistance: spreadDistanceLength color: colorOrNamedConstant [
 
 	^ self
 		withAll:
@@ -63,17 +60,17 @@ CssBoxShadow class >> horizontalOffset: horizontalOffsetLength verticalOffset: v
 			verticalOffsetLength.
 			blurRadiusLength.
 			spreadDistanceLength.
-			color}
+			(self lookupColor: colorOrNamedConstant)}
 ]
 
 { #category : #'Instance Creation' }
-CssBoxShadow class >> horizontalOffset: horizontalOffsetLength verticalOffset: verticalOffsetLength color: color [
+CssBoxShadow class >> horizontalOffset: horizontalOffsetLength verticalOffset: verticalOffsetLength color: colorOrNamedConstant [
 
 	^ self
 		withAll:
 			{horizontalOffsetLength.
 			verticalOffsetLength.
-			color}
+			(self lookupColor: colorOrNamedConstant)}
 ]
 
 { #category : #private }
@@ -92,7 +89,7 @@ CssBoxShadow >> , aCssBoxShadow [
 CssBoxShadow >> beInset [
 
 	components := components asOrderedCollection
-		addFirst: CssConstants >> #inset;
+		addFirst: (self class lookupValue: #inset);
 		asArray
 ]
 

--- a/source/RenoirSt/CssColorStop.class.st
+++ b/source/RenoirSt/CssColorStop.class.st
@@ -15,7 +15,7 @@ Class {
 { #category : #'Instance Creation' }
 CssColorStop class >> for: aCssColor at: aLenght [
 
-	^self new initializeFor: aCssColor at: aLenght
+	^ self new initializeFor: (self lookupColor: aCssColor) at: aLenght
 ]
 
 { #category : #Printing }

--- a/source/RenoirSt/CssDeclarationBlock.class.st
+++ b/source/RenoirSt/CssDeclarationBlock.class.st
@@ -662,9 +662,9 @@ CssDeclarationBlock >> printInlinedOn: aStream [
 ]
 
 { #category : #private }
-CssDeclarationBlock >> propertyAt: aPropertyName put: aValue [
-	
-	declarations add: (rulePrecedencePolicy applyTo: (CssDeclaration property: aPropertyName value: aValue))
+CssDeclarationBlock >> propertyAt: aPropertyName put: aNamedConstantOrValue [
+
+	declarations add: (rulePrecedencePolicy applyTo: (CssDeclaration property: aPropertyName value: (self class lookupValue: aNamedConstantOrValue)))
 ]
 
 { #category : #'generated content properties' }

--- a/source/RenoirSt/CssExternalFontReference.class.st
+++ b/source/RenoirSt/CssExternalFontReference.class.st
@@ -8,9 +8,6 @@ Class {
 		'url',
 		'format'
 	],
-	#pools : [
-		'RenoirSt'
-	],
 	#category : #'RenoirSt-Fonts'
 }
 
@@ -21,15 +18,15 @@ CssExternalFontReference class >> locatedAt: anUrl [
 ]
 
 { #category : #'Instance Creation' }
-CssExternalFontReference class >> locatedAt: anUrl withFormat: aFontFormatString [
-		
-	^self new initializeLocatedAt: anUrl withFormat: aFontFormatString 
+CssExternalFontReference class >> locatedAt: anUrl withFormat: aNamedConstantOrFontFormatString [
+
+	^ self new initializeLocatedAt: anUrl withFormat: (self lookupValue: aNamedConstantOrFontFormatString)
 ]
 
 { #category : #'Instance Creation' }
 CssExternalFontReference class >> svgFontLocatedAt: aUrl withId: aString [
 
-	^ self locatedAt: (CssSVGFontLocation at: aUrl withId: aString) withFormat: CssConstants >> #svg
+	^ self locatedAt: (CssSVGFontLocation at: aUrl withId: aString) withFormat: #svg
 ]
 
 { #category : #Printing }

--- a/source/RenoirSt/CssGradient.class.st
+++ b/source/RenoirSt/CssGradient.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'RenoirSt-Colors'
 }
 
+{ #category : #converting }
+CssGradient class >> asColorStops: aColorStopOrNamedConstantCollection [
+
+	^ aColorStopOrNamedConstantCollection collect: [ :colorStopOrNamedConstant | self lookupColor: colorStopOrNamedConstant ]
+]
+
 { #category : #private }
 CssGradient >> colorStops [
 

--- a/source/RenoirSt/CssLinearGradient.class.st
+++ b/source/RenoirSt/CssLinearGradient.class.st
@@ -19,9 +19,9 @@ CssLinearGradient class >> fading: aColorStopCollection [
 ]
 
 { #category : #private }
-CssLinearGradient class >> in: aDirection fading: aColorStopCollection [ 
-	
-	^self new initializeIn: aDirection fading: aColorStopCollection 
+CssLinearGradient class >> in: aDirection fading: aColorStopCollection [
+
+	^ self new initializeIn: aDirection fading: (self asColorStops: aColorStopCollection)
 ]
 
 { #category : #'Instance Creation' }

--- a/source/RenoirSt/CssMediaQueryExpression.class.st
+++ b/source/RenoirSt/CssMediaQueryExpression.class.st
@@ -54,5 +54,5 @@ CssMediaQueryExpression >> cssContentOn: aStream [
 CssMediaQueryExpression >> initializeForFeatureNamed: aString withValues: aCollection [
 
 	mediaFeature := aString.
-	values := aCollection
+	values := aCollection collect: [ :aValue | CssMediaQueryConstants at: aValue ifAbsent: [ aValue ] ]
 ]

--- a/source/RenoirSt/CssObject.class.st
+++ b/source/RenoirSt/CssObject.class.st
@@ -5,8 +5,29 @@ A CssObject is the abstract superclass of the CSS renderable objects
 Class {
 	#name : #CssObject,
 	#superclass : #Object,
+	#pools : [
+		'RenoirSt'
+	],
 	#category : #'RenoirSt-Common'
 }
+
+{ #category : #'private - converting' }
+CssObject class >> lookupColor: aNamedConstantOrCssColor [
+
+	"Lookup the SVG colors namespace, if no named constant is found return the argument"
+
+	^ CssConstants >> #colors at: aNamedConstantOrCssColor ifAbsent: [ aNamedConstantOrCssColor ]
+]
+
+{ #category : #'private - converting' }
+CssObject class >> lookupValue: aNamedConstantOrValue [
+
+	"Lookup the CSS namespace and the SVG colors namespace, if no named constant is found returns the argument"
+
+	^ (aNamedConstantOrValue isCollection and: [ aNamedConstantOrValue isString not ])
+		ifTrue: [ aNamedConstantOrValue collect: [ :each | self lookupValue: each ] ]
+		ifFalse: [ CssConstants at: aNamedConstantOrValue ifAbsent: [ self lookupColor: aNamedConstantOrValue ] ]
+]
 
 { #category : #Printing }
 CssObject >> cssContentOn: aStream [

--- a/source/RenoirSt/CssPseudoClassSelector.class.st
+++ b/source/RenoirSt/CssPseudoClassSelector.class.st
@@ -29,9 +29,9 @@ CssPseudoClassSelector class >> checkedOn: aSelector [
 ]
 
 { #category : #'Instance Creation' }
-CssPseudoClassSelector class >> childAt: anInteger on: aSelector [ 
-	
-	^self named: 'nth-child' withArguments: { anInteger } over: aSelector 
+CssPseudoClassSelector class >> childAt: aNamedConstantOrInteger on: aSelector [
+
+	^ self named: 'nth-child' withArguments: {(self lookupValue: aNamedConstantOrInteger)} over: aSelector
 ]
 
 { #category : #'Instance Creation' }
@@ -143,9 +143,9 @@ CssPseudoClassSelector class >> rootOn: aSelector [
 ]
 
 { #category : #'Instance Creation' }
-CssPseudoClassSelector class >> siblingOfTypeAt: anInteger on: aSelector [ 
+CssPseudoClassSelector class >> siblingOfTypeAt: aNamedConstantOrInteger on: aSelector [
 
-	^self named: 'nth-of-type' withArguments: { anInteger } over: aSelector
+	^ self named: 'nth-of-type' withArguments: {(self lookupValue: aNamedConstantOrInteger)} over: aSelector
 ]
 
 { #category : #'Instance Creation' }

--- a/source/RenoirSt/CssRadialGradient.class.st
+++ b/source/RenoirSt/CssRadialGradient.class.st
@@ -15,7 +15,7 @@ Class {
 { #category : #'Instance Creation' }
 CssRadialGradient class >> circular: aRadiusOrKeyword at: aPosition fading: colorStops [ 
 	
-	^self shape: (CssGradientComponent on: { aRadiusOrKeyword . 'circle'. 'at'. aPosition }) fading: colorStops
+	^self shape: (CssGradientComponent on: { aRadiusOrKeyword . 'circle'. 'at'. self lookupValue: aPosition }) fading: colorStops
 ]
 
 { #category : #'Instance Creation' }
@@ -26,15 +26,9 @@ CssRadialGradient class >> circular: aRadiusOrKeyword fading: colorStops [
 
 { #category : #'Instance Creation' }
 CssRadialGradient class >> elliptical: aCssValue at: aPosition fading: colorStops [
-	
+
 	^ self
-		shape:
-			(CssGradientComponent
-				on:
-					{aCssValue.
-					'ellipse'.
-					'at'.
-					aPosition})
+		shape:(CssGradientComponent on: {aCssValue. 'ellipse'. 'at'. (self lookupValue: aPosition)})
 		fading: colorStops
 ]
 
@@ -51,9 +45,9 @@ CssRadialGradient class >> fading: aColorStopCollection [
 ]
 
 { #category : #private }
-CssRadialGradient class >> shape: aShapeSpec fading: aColorStopCollection [ 
-	
-	^self new initializeShape: aShapeSpec fading: aColorStopCollection 
+CssRadialGradient class >> shape: aShapeSpec fading: aColorStopCollection [
+
+	^ self new initializeShape: aShapeSpec fading: (self asColorStops: aColorStopCollection)
 ]
 
 { #category : #Configuring }

--- a/source/RenoirSt/CssToggle.class.st
+++ b/source/RenoirSt/CssToggle.class.st
@@ -11,9 +11,9 @@ Class {
 }
 
 { #category : #'Instance Creation' }
-CssToggle class >> cyclingOver: aCollection [ 
-	
-	^self new initializeCyclingOver: aCollection 
+CssToggle class >> cyclingOver: aCollection [
+
+	^ self new initializeCyclingOver: (self lookupValue: aCollection)
 ]
 
 { #category : #private }

--- a/source/RenoirSt/RenoirSt.class.st
+++ b/source/RenoirSt/RenoirSt.class.st
@@ -31,7 +31,7 @@ RenoirSt class >> initialize [
 RenoirSt class >> initializeAttachmentConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #fixed to: 'fixed';
 		bind: #scroll to: 'scroll'
 ]
@@ -40,7 +40,7 @@ RenoirSt class >> initializeAttachmentConstants [
 RenoirSt class >> initializeBackgroundConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #borderBox to: 'border-box';
 		bind: #closestCorner to: 'closest-corner';
 		bind: #closestSide to: 'closest-side';
@@ -57,7 +57,7 @@ RenoirSt class >> initializeBackgroundConstants [
 RenoirSt class >> initializeBasicConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #auto to: 'auto';
 		bind: #even to: 'even';
 		bind: #hide to: 'hide';
@@ -74,7 +74,7 @@ RenoirSt class >> initializeBasicConstants [
 RenoirSt class >> initializeBorderConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #collapse to: 'collapse';
 		bind: #dashed to: 'dashed';
 		bind: #dotted to: 'dotted';
@@ -123,7 +123,7 @@ RenoirSt class >> initializeCssConstants [
 RenoirSt class >> initializeCursorConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #crosshair to: 'crosshair';
 		bind: #default to: 'default';
 		bind: #help to: 'help';
@@ -139,7 +139,7 @@ RenoirSt class >> initializeCursorConstants [
 RenoirSt class >> initializeDisplayConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #block to: 'block';
 		bind: #inline to: 'inline';
 		bind: #inlineBlock to: 'inline-block';
@@ -160,7 +160,7 @@ RenoirSt class >> initializeDisplayConstants [
 RenoirSt class >> initializeFontConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #bold to: 'bold';
 		bind: #bolder to: 'bolder';
 		bind: #caption to: 'caption';
@@ -180,7 +180,7 @@ RenoirSt class >> initializeFontConstants [
 RenoirSt class >> initializeFontFormatConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #svg to: 'svg';
 		bind: #truetype to: 'truetype';
 		bind: #opentype to: 'opentype';
@@ -192,7 +192,7 @@ RenoirSt class >> initializeFontFormatConstants [
 RenoirSt class >> initializeFontSizeConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #smaller to: 'smaller';
 		bind: #xxSmall to: 'xx-small';
 		bind: #xSmall to: 'x-small';
@@ -207,7 +207,7 @@ RenoirSt class >> initializeFontSizeConstants [
 RenoirSt class >> initializeFontStretchingConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #extraCondensed to: 'extra-condensed';
 		bind: #ultraExpanded to: 'ultra-expanded';
 		bind: #extraExpanded to: 'extra-expanded';
@@ -222,7 +222,7 @@ RenoirSt class >> initializeFontStretchingConstants [
 RenoirSt class >> initializeFontSynthesisConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #style to: 'style';
 		bind: #weight to: 'weight'
 ]
@@ -231,7 +231,7 @@ RenoirSt class >> initializeFontSynthesisConstants [
 RenoirSt class >> initializeFontVariantConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #noContextual to: 'no-contextual';
 		bind: #noCommonLigatures to: 'no-common-ligatures';
 		bind: #diagonalFractions to: 'diagonal-fractions';
@@ -261,7 +261,7 @@ RenoirSt class >> initializeFontVariantConstants [
 RenoirSt class >> initializeGenericFontFamilyConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #fantasy to: 'fantasy';
 		bind: #monospace to: 'monospace';
 		bind: #serif to: 'serif';
@@ -274,7 +274,7 @@ RenoirSt class >> initializeLengthUnits [
 
 	<ignoreForCoverage>
 	"Absolute Units"
-	(CssConstants >> #units)
+	(self constants >> #units)
 		bind: #centimeter to: (CssUnit identifiedBy: 'cm');
 		bind: #inch to: (CssUnit identifiedBy: 'in');
 		bind: #millimeter to: (CssUnit identifiedBy: 'mm');
@@ -282,7 +282,7 @@ RenoirSt class >> initializeLengthUnits [
 		bind: #pixel to: (CssUnit identifiedBy: 'px');
 		bind: #point to: (CssUnit identifiedBy: 'pt').
 	"Relative Units"
-	(CssConstants >> #units)
+	(self constants >> #units)
 		bind: #fontSize to: (CssUnit identifiedBy: 'em');
 		bind: #xHeight to: (CssUnit identifiedBy: 'ex');
 		bind: #zeroWidth to: (CssUnit identifiedBy: 'ch');
@@ -297,7 +297,7 @@ RenoirSt class >> initializeLengthUnits [
 RenoirSt class >> initializeListConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #armenian to: 'armenian';
 		bind: #circle to: 'circle';
 		bind: #decimal to: 'decimal';
@@ -346,7 +346,7 @@ RenoirSt class >> initializeMediaQueryConstants [
 RenoirSt class >> initializePositioningConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #absolute to: 'absolute';
 		bind: #always to: 'always';
 		bind: #avoid to: 'avoid';
@@ -371,7 +371,7 @@ RenoirSt class >> initializePositioningConstants [
 RenoirSt class >> initializeRepeatConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #noRepeat to: 'no-repeat';
 		bind: #repeat to: 'repeat';
 		bind: #repeatX to: 'repeat-x';
@@ -382,8 +382,8 @@ RenoirSt class >> initializeRepeatConstants [
 RenoirSt class >> initializeSVGColors [
 
 	<ignoreForCoverage>
-	CssConstants bind: #colors to: Namespace new.
-	CssConstants >> #colors bind: #transparent to: 'transparent'.
+	self constants bind: #colors to: Namespace new.
+	self constants >> #colors bind: #transparent to: 'transparent'.
 	self
 		initializeSVGColors1;
 		initializeSVGColors2;
@@ -394,7 +394,7 @@ RenoirSt class >> initializeSVGColors [
 RenoirSt class >> initializeSVGColors1 [
 
 	<ignoreForCoverage>
-	(CssConstants >> #colors)
+	(self constants >> #colors)
 		bind: #aliceBlue to: ((CssRGBColor red: 240 green: 248 blue: 255) identifiedBy: 'aliceblue');
 		bind: #antiqueWhite to: ((CssRGBColor red: 250 green: 235 blue: 215) identifiedBy: 'antiquewhite');
 		bind: #aqua to: ((CssRGBColor red: 0 green: 255 blue: 255) identifiedBy: 'aqua');
@@ -450,7 +450,7 @@ RenoirSt class >> initializeSVGColors1 [
 RenoirSt class >> initializeSVGColors2 [
 
 	<ignoreForCoverage>
-	(CssConstants >> #colors)
+	(self constants >> #colors)
 		bind: #gainsboro to: ((CssRGBColor red: 220 green: 220 blue: 220) identifiedBy: 'gainsboro');
 		bind: #ghostWhite to: ((CssRGBColor red: 248 green: 248 blue: 255) identifiedBy: 'ghostwhite');
 		bind: #gold to: ((CssRGBColor red: 255 green: 215 blue: 0) identifiedBy: 'gold');
@@ -493,7 +493,7 @@ RenoirSt class >> initializeSVGColors2 [
 RenoirSt class >> initializeSVGColors3 [
 
 	<ignoreForCoverage>
-	(CssConstants >> #colors)
+	(self constants >> #colors)
 		bind: #magenta to: ((CssRGBColor red: 255 green: 0 blue: 255) identifiedBy: 'magenta');
 		bind: #maroon to: ((CssRGBColor red: 128 green: 0 blue: 0) identifiedBy: 'maroon');
 		bind: #mediumAquamarine to: ((CssRGBColor red: 102 green: 205 blue: 170) identifiedBy: 'mediumaquamarine');
@@ -562,7 +562,7 @@ RenoirSt class >> initializeSVGColors3 [
 RenoirSt class >> initializeSizeConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #contain to: 'contain';
 		bind: #cover to: 'cover'
 ]
@@ -571,7 +571,7 @@ RenoirSt class >> initializeSizeConstants [
 RenoirSt class >> initializeTextConstants [
 
 	<ignoreForCoverage>
-	CssConstants
+	self constants
 		bind: #blink to: 'blink';
 		bind: #breakWord to: 'break-word';
 		bind: #capitalize to: 'capitalize';
@@ -599,25 +599,25 @@ RenoirSt class >> initializeTextConstants [
 RenoirSt class >> initializeUnits [
 
 	<ignoreForCoverage>
-	CssConstants bind: #units to: Namespace new.
+	self constants bind: #units to: Namespace new.
 	self initializeLengthUnits.
 	"Angle"
-	(CssConstants >> #units)
+	(self constants >> #units)
 		bind: #degree to: (CssUnit identifiedBy: 'deg');
 		bind: #radian to: (CssUnit identifiedBy: 'rad');
 		bind: #gradian to: (CssUnit identifiedBy: 'grad');
 		bind: #turn to: (CssUnit identifiedBy: 'turn').
 	"Frequency"
-	(CssConstants >> #units)
+	(self constants >> #units)
 		bind: #hertz to: (CssUnit identifiedBy: 'Hz');
 		bind: #kiloHertz to: (CssUnit identifiedBy: 'kHz').
 	"Resolution"
-	(CssConstants >> #units)
+	(self constants >> #units)
 		bind: #dotsPerCentimeter to: (CssUnit identifiedBy: 'dpcm');
 		bind: #dotsPerInch to: (CssUnit identifiedBy: 'dpi');
 		bind: #dotsPerPixelUnit to: (CssUnit identifiedBy: 'dppx').
 	"Time"
-	(CssConstants >> #units)
+	(self constants >> #units)
 		bind: #second to: (CssUnit identifiedBy: 's');
 		bind: #millisecond to: (CssUnit identifiedBy: 'ms')
 ]


### PR DESCRIPTION
Changed the code base to automatically resolve the constant references in the supported places.
So now you just write `#red` , `#lowerRoman` or `#print` instead of `CssConstants >> #colors >> #red` , `CssConstants >> #lowerRoman` or `CssMediaQueryConstants >> #print`.

Now writing the style in the rules is almost the same as writing plain CSS.